### PR TITLE
Fix float parser: only find-replace D/E in values, not in keys

### DIFF
--- a/hydrolib/core/io/ini/parser.py
+++ b/hydrolib/core/io/ini/parser.py
@@ -292,11 +292,27 @@ class Parser:
             config = ParserConfig()
         parser = cls(config)
 
+        progline = re.compile(
+            r"^([^#]*=\s*)([^#]*)(#.*)?"
+        )  # matches whole line: "Field = Value Maybe more # optional comment"
+        progfloat = re.compile(
+            r"([\d.]+)([dD])([+\-]?\d+)"
+        )  # matches a float value: 1d9, 1D-3, 1.D+4, etc.
+
         with filepath.open() as f:
             for line in f:
                 # Replace Fortran scientific notation for doubles
                 # Match number d/D +/- number (e.g. 1d-05 or 1.23D+01 or 1.d-4)
-                line = re.sub(r"([\d.]+)([dD])([+\-]?\d+)", r"\1e\3", line)
+                match = progline.match(line)
+                if match:  # Only process value
+                    line = (
+                        match.group(1)
+                        + progfloat.sub(r"\1e\3", match.group(2))
+                        + str(match.group(3) or "")
+                    )
+                else:  # Process full line
+                    line = progfloat.sub(r"\1e\3", line)
+
                 parser.feed_line(line)
 
         return parser.finalize().flatten()

--- a/tests/io/test_ini.py
+++ b/tests/io/test_ini.py
@@ -334,6 +334,28 @@ class TestParser:
         parser = Parser(config)
         assert parser._is_datarow(line) == expected_result
 
+    @pytest.mark.parametrize(
+        "line,expected_key,expected_value",
+        [
+            ("someParam = 1.0 # comment text", "someparam", "1.0"),
+            ("someParam = 1.0", "someparam", "1.0"),
+            ("someParam = 1d0 # comment text", "someparam", "1e0"),
+            ("someParam = 1d-2", "someparam", "1e-2"),
+            ("someParam = 1d+2", "someparam", "1e+2"),
+            ("someParam = 1.d+2", "someparam", "1.e+2"),
+            ("someParam = -1.d-2", "someparam", "-1.e-2"),
+            ("someParam1D2D = -1.d-2", "someparam1d2d", "-1.e-2"),
+        ],
+    )
+    def test_float_values(
+        self, tmp_path, line: str, expected_key: str, expected_value: str
+    ):
+        parser = Parser(ParserConfig())
+        p = tmp_path / "test.ini"
+        p.write_text("[sectionA]\n" + line)
+        result = Parser.parse(p)
+        assert result["sectiona"][expected_key] == expected_value
+
     def test_feed_comment_at_the_beginning_of_the_document_gets_added_to_the_header(
         self,
     ):

--- a/tests/io/test_ini.py
+++ b/tests/io/test_ini.py
@@ -350,7 +350,6 @@ class TestParser:
     def test_float_values(
         self, tmp_path, line: str, expected_key: str, expected_value: str
     ):
-        parser = Parser(ParserConfig())
         p = tmp_path / "test.ini"
         p.write_text("[sectionA]\n" + line)
         result = Parser.parse(p)


### PR DESCRIPTION
Fixes #103 