### PR TITLE
Set the python version in sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,3 +10,5 @@ sonar.organization=deltares
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
+
+sonar.python.version=3.8, 3.9


### PR DESCRIPTION
- Set the sonar.python.version to 3.8 and 3.9 to obtain a more detailed
  analysis.