### PR TITLE
Feature/114 crsdef tests

### DIFF
--- a/hydrolib/core/io/ini/models.py
+++ b/hydrolib/core/io/ini/models.py
@@ -16,7 +16,6 @@ from typing import (
     Union,
 )
 
-from _typeshed import Self
 from pydantic import Extra, Field, root_validator
 from pydantic.class_validators import validator
 
@@ -315,9 +314,9 @@ class CrossSectionDefinition(INIBasedModel):
         Returns:
             bool: True when input is valid, False otherwise.
         """
-        frictionid = getattr(cls, frictionid_attr, "")
-        frictiontype = getattr(cls, frictiontype_attr, "")
-        frictionvalue = getattr(cls, frictionvalue_attr, "")
+        frictionid = values.get(frictionid_attr) or ""
+        frictiontype = values.get(frictiontype_attr) or ""
+        frictionvalue = values.get(frictionvalue_attr) or ""
 
         if frictionid == "":
             if frictiontype == "" or frictionvalue == "":
@@ -391,7 +390,7 @@ class CircleCrsDef(CrossSectionDefinition):
             dict: Dictionary of validated values.
         """
         if CrossSectionDefinition._validate_friction_specification(
-            cls, values, "frictionid", "frictiontype", "frictionvalue"
+            values, "frictionid", "frictiontype", "frictionvalue"
         ):
             return values
 

--- a/hydrolib/core/io/ini/models.py
+++ b/hydrolib/core/io/ini/models.py
@@ -424,6 +424,26 @@ class RectangleCrsDef(CrossSectionDefinition):
     frictiontype: Optional[str] = Field(alias="frictionType")
     frictionvalue: Optional[float] = Field(alias="frictionValue")
 
+    @root_validator
+    @classmethod
+    def check_friction(cls, values: dict) -> dict:
+        """
+        Verifies whether the crosssection definition has a valid friction specification.
+
+        Args:
+            values (dict): Dictionary of validated values to create a CrossSectionDefinition subclass.
+
+        Raises:
+            ValueError: When the values dictionary does not contain valid friction keys.
+
+        Returns:
+            dict: Dictionary of validated values.
+        """
+        if CrossSectionDefinition._validate_friction_specification(
+            values, "frictionid", "frictiontype", "frictionvalue"
+        ):
+            return values
+
 
 class ZWRiverCrsDef(CrossSectionDefinition):
     class Comments(CrossSectionDefinition.Comments):
@@ -520,6 +540,26 @@ class ZWRiverCrsDef(CrossSectionDefinition):
         "frictiontypes",
         delimiter=";",
     )
+
+    @root_validator
+    @classmethod
+    def check_friction(cls, values: dict) -> dict:
+        """
+        Verifies whether the crosssection definition has a valid friction specification.
+
+        Args:
+            values (dict): Dictionary of validated values to create a CrossSectionDefinition subclass.
+
+        Raises:
+            ValueError: When the values dictionary does not contain valid friction keys.
+
+        Returns:
+            dict: Dictionary of validated values.
+        """
+        if CrossSectionDefinition._validate_friction_specification(
+            values, "frictionids", "frictiontypes", "frictionvalues"
+        ):
+            return values
 
 
 class ZWCrsDef(CrossSectionDefinition):

--- a/tests/io/test_crosssection.py
+++ b/tests/io/test_crosssection.py
@@ -1,0 +1,68 @@
+import inspect
+from contextlib import nullcontext as does_not_raise
+from pathlib import Path
+from typing import Any, Callable, List, Union
+
+import pytest
+from pydantic.error_wrappers import ValidationError
+
+from hydrolib.core.io.ini.models import (
+    CircleCrsDef,
+    CrossDefModel,
+    CrossSectionDefinition,
+    RectangleCrsDef,
+    XYZCrsDef,
+    YZCrsDef,
+    ZWCrsDef,
+    ZWRiverCrsDef,
+)
+from hydrolib.core.io.ini.parser import Parser, ParserConfig
+
+from ..utils import WrapperTest, test_data_dir
+
+
+def test_crossdef_model():
+    filepath = test_data_dir / "input/TMP_dflowfm_individual_files/crsdef1.ini"
+    m = CrossDefModel(filepath)
+    assert len(m.definition) == 4
+
+    assert isinstance(m.definition[0], CircleCrsDef)
+    assert m.definition[0].id == "Prof1"
+    assert m.definition[0].thalweg == 0.0
+    assert m.definition[0].diameter == 2.0
+    assert m.definition[0].frictionid == "Brick"
+
+
+def test_create_a_circlecrsdef_from_scratch():
+    cd = CircleCrsDef(
+        id="Prof1",
+        diameter=3.14,
+        frictiontype="wallLawNikuradse",
+        frictionvalue=[1.5],
+    )
+    assert cd.id == "Prof1"
+    assert cd.diameter == 3.14
+    assert cd.frictiontype == "wallLawNikuradse"
+    assert cd.frictionvalue == 1.5
+
+
+def test_create_a_circlecrsdef_with_duplicate_frictionspec():
+    csdefid = "Prof1"
+    with pytest.raises(ValidationError) as error:
+        cd = CircleCrsDef(
+            id=csdefid,
+            diameter=3.14,
+            frictionid="Brick",
+            frictiontype="wallLawNikuradse",
+            frictionvalue=1.5,
+        )
+    expected_message = (
+        f'Cross section with id "{csdefid}" has duplicate friction specification'
+    )
+
+    assert expected_message in str(error.value)
+
+    # assert cd.id == "Prof1"
+    # assert cd.diameter == 3.14
+    # assert cd.frictiontype == "wallLawNikuradse"
+    # assert cd.frictionvalue == 1.5

--- a/tests/io/test_crosssection.py
+++ b/tests/io/test_crosssection.py
@@ -41,6 +41,7 @@ def test_create_a_circlecrsdef_from_scratch():
         frictionvalue=1.5,
     )
     assert cd.id == "Prof1"
+    assert cd.type == "circle"
     assert cd.diameter == 3.14
     assert cd.frictiontype == "wallLawNikuradse"
     assert cd.frictionvalue == 1.5
@@ -58,6 +59,71 @@ def test_create_a_circlecrsdef_with_duplicate_frictionspec():
         )
     expected_message = (
         f'Cross section with id "{csdefid}" has duplicate friction specification'
+    )
+
+    assert expected_message in str(error.value)
+
+
+def test_create_a_rectanglecrsdef_from_scratch():
+    cd = RectangleCrsDef(
+        id="Prof1",
+        width=3.14,
+        height=2.718,
+        frictiontype="wallLawNikuradse",
+        frictionvalue=1.5,
+    )
+    assert cd.id == "Prof1"
+    assert cd.type == "rectangle"
+    assert cd.width == 3.14
+    assert cd.height == 2.718
+    assert cd.frictiontype == "wallLawNikuradse"
+    assert cd.frictionvalue == 1.5
+
+
+def test_create_a_rectanglecrsdef_without_frictionspec():
+    csdefid = "Prof1"
+    with pytest.raises(ValidationError) as error:
+        cd = RectangleCrsDef(
+            id=csdefid,
+            width=3.14,
+            height=2.718,
+        )
+    expected_message = (
+        f'Cross section with id "{csdefid}" is missing any friction specification.'
+    )
+
+    assert expected_message in str(error.value)
+
+
+def test_create_a_zwrivercrsdef_from_scratch():
+    cd = ZWRiverCrsDef(
+        id="Prof1",
+        numlevels=2,
+        levels=[-2, 3],
+        flowwidths=[11, 44],
+        frictiontypes=["Manning"],
+        frictionvalues=[0.03],
+    )
+    assert cd.id == "Prof1"
+    assert cd.type == "zwRiver"
+    assert cd.numlevels == 2
+    assert cd.levels == [-2, 3]
+    assert cd.flowwidths == [11, 44]
+    assert cd.frictiontypes == ["Manning"]
+    assert cd.frictionvalues == [0.03]
+
+
+def test_create_a_zwrivercrsdef_without_frictionspec():
+    csdefid = "Prof1"
+    with pytest.raises(ValidationError) as error:
+        cd = ZWRiverCrsDef(
+            id=csdefid,
+            numlevels=2,
+            levels=[-2, 3],
+            flowwidths=[11, 44],
+        )
+    expected_message = (
+        f'Cross section with id "{csdefid}" is missing any friction specification.'
     )
 
     assert expected_message in str(error.value)

--- a/tests/io/test_crosssection.py
+++ b/tests/io/test_crosssection.py
@@ -38,7 +38,7 @@ def test_create_a_circlecrsdef_from_scratch():
         id="Prof1",
         diameter=3.14,
         frictiontype="wallLawNikuradse",
-        frictionvalue=[1.5],
+        frictionvalue=1.5,
     )
     assert cd.id == "Prof1"
     assert cd.diameter == 3.14
@@ -61,8 +61,3 @@ def test_create_a_circlecrsdef_with_duplicate_frictionspec():
     )
 
     assert expected_message in str(error.value)
-
-    # assert cd.id == "Prof1"
-    # assert cd.diameter == 3.14
-    # assert cd.frictiontype == "wallLawNikuradse"
-    # assert cd.frictionvalue == 1.5


### PR DESCRIPTION
Fixes #144. (sorry, branch name has a typo 114)

Any idea on how to reduce copy-pasted code in my commits?
I did split off a reusable function ```CrossSectionDefinition._validate_friction_specification()```, but the ```check_friction``` validators in ```CircleCrsDef```, ```RectangleCrsDef``` and ```ZwRiverCrsDef``` are really copy-pasted, and the unit tests in ```test_crosssection.py``` are also really quite similar.
I still have three more subclasses to go...