### PR TITLE
Feature/144 crsdef tests

### DIFF
--- a/hydrolib/core/io/bc/models.py
+++ b/hydrolib/core/io/bc/models.py
@@ -122,7 +122,7 @@ class ForcingBase(DataBlockINIBasedModel):
         return v
 
     def _get_identifier(self, data: dict) -> Optional[str]:
-        return data["name"] if "name" in data else None
+        return data.get("name")
 
     def _to_section(self) -> Section:
         section = super()._to_section()

--- a/hydrolib/core/io/dimr/models.py
+++ b/hydrolib/core/io/dimr/models.py
@@ -69,7 +69,7 @@ class Component(BaseModel, ABC):
         return True
 
     def _get_identifier(self, data: dict) -> Optional[str]:
-        return data["name"] if "name" in data else None
+        return data.get("name")
 
 
 class FMComponent(Component):
@@ -125,7 +125,7 @@ class ComponentOrCouplerRef(BaseModel):
     name: str
 
     def _get_identifier(self, data: dict) -> Optional[str]:
-        return data["name"] if "name" in data else None
+        return data.get("name")
 
 
 class CoupledItem(BaseModel):
@@ -185,7 +185,7 @@ class Coupler(BaseModel):
         return False
 
     def _get_identifier(self, data: dict) -> Optional[str]:
-        return data["name"] if "name" in data else None
+        return data.get("name")
 
 
 class StartGroup(BaseModel):

--- a/hydrolib/core/io/ext/models.py
+++ b/hydrolib/core/io/ext/models.py
@@ -58,7 +58,7 @@ class Boundary(INIBasedModel):
         Returns:
             str: The nodeid value or None if not found.
         """
-        return data.get("nodeid", None)
+        return data.get("nodeid")
 
     @property
     def forcing(self) -> ForcingBase:
@@ -101,7 +101,7 @@ class Lateral(INIBasedModel):
     )
 
     def _get_identifier(self, data: dict) -> Optional[str]:
-        return data["id"] if "id" in data else None
+        return data.get("id")
 
     @validator("xcoordinates", "ycoordinates")
     @classmethod

--- a/hydrolib/core/io/ini/models.py
+++ b/hydrolib/core/io/ini/models.py
@@ -25,7 +25,7 @@ from hydrolib.core.io.base import DummySerializer
 from hydrolib.core.io.ini.util import (
     get_from_subclass_defaults,
     get_split_string_on_delimiter_validator,
-    make_list_length_validator,
+    make_list_length_root_validator,
 )
 
 from .io_models import (
@@ -515,19 +515,13 @@ class ZWRiverCrsDef(CrossSectionDefinition):
         "frictionids", "frictiontypes", "frictionvalues"
     )
 
-    @root_validator
-    @classmethod
-    def check_lists(cls, values: dict) -> dict:
-        _check_list_length = make_list_length_validator(
-            "levels",
-            "flowwidths",
-            "totalwidths",
-            length=values["numlevels"],
-            length_name="numlevels",
-            annotation=f"id = {values['id']}",
-        )
-
-        return values
+    _check_list_length = make_list_length_root_validator(
+        "levels",
+        "flowwidths",
+        "totalwidths",
+        length_name="numlevels",
+        annotation="id",
+    )
 
 
 class ZWCrsDef(CrossSectionDefinition):

--- a/hydrolib/core/io/ini/models.py
+++ b/hydrolib/core/io/ini/models.py
@@ -324,12 +324,12 @@ class CrossSectionDefinition(INIBasedModel):
             if frictionid == "":
                 if frictiontype == "" or frictionvalue == "":
                     raise ValueError(
-                        f"Cross section with id \"{values.get('id', '')}\" is missing any friction specification."
+                        f"Cross section is missing any friction specification."
                     )
             else:
                 if frictiontype != "" or frictionvalue != "":
                     raise ValueError(
-                        f"Cross section with id \"{values.get('id', '')}\" has duplicate friction specification (both {frictionid_attr} and {frictiontype_attr}/{frictionvalue_attr})."
+                        f"Cross section has duplicate friction specification (both {frictionid_attr} and {frictiontype_attr}/{frictionvalue_attr})."
                     )
 
             return values
@@ -518,7 +518,6 @@ class ZWRiverCrsDef(CrossSectionDefinition):
         "flowwidths",
         "totalwidths",
         length_name="numlevels",
-        id_name="id",
     )
 
 
@@ -579,7 +578,6 @@ class ZWCrsDef(CrossSectionDefinition):
         "flowwidths",
         "totalwidths",
         length_name="numlevels",
-        id_name="id",
     )
 
     _friction_validator = CrossSectionDefinition._get_friction_root_validator(
@@ -666,7 +664,6 @@ class YZCrsDef(CrossSectionDefinition):
         "ycoordinates",
         "zcoordinates",
         length_name="yzcount",
-        id_name="id",
     )
 
     _check_frictlist_length = make_list_length_root_validator(
@@ -674,12 +671,10 @@ class YZCrsDef(CrossSectionDefinition):
         "frictiontypes",
         "frictionvalues",
         length_name="sectioncount",
-        id_name="id",
     )
     _check_frictlist_length1 = make_list_length_root_validator(
         "frictionpositions",
         length_name="sectioncount",
-        id_name="id",
         length_incr=1,  # 1 extra for frictionpositions
     )
 
@@ -761,13 +756,11 @@ class XYZCrsDef(YZCrsDef, CrossSectionDefinition):
         "ycoordinates",
         "zcoordinates",
         length_name="xyzcount",
-        id_name="id",
     )
 
     _check_xlist_length = make_list_length_root_validator(
         "xcoordinates",
         length_name="xyzcount",
-        id_name="id",
     )
 
 

--- a/hydrolib/core/io/ini/models.py
+++ b/hydrolib/core/io/ini/models.py
@@ -253,7 +253,7 @@ class CrossSectionDefinition(INIBasedModel):
     thalweg: Optional[float]
 
     def _get_identifier(self, data: dict) -> Optional[str]:
-        return data["id"]
+        return data.get("id")
 
     @classmethod
     def _duplicate_keys_as_list(cls):

--- a/hydrolib/core/io/ini/models.py
+++ b/hydrolib/core/io/ini/models.py
@@ -16,7 +16,6 @@ from typing import (
     Union,
 )
 
-from _typeshed import Self
 from pydantic import Extra, Field, root_validator
 from pydantic.class_validators import validator
 
@@ -315,9 +314,9 @@ class CrossSectionDefinition(INIBasedModel):
         Returns:
             bool: True when input is valid, False otherwise.
         """
-        frictionid = getattr(cls, frictionid_attr, "")
-        frictiontype = getattr(cls, frictiontype_attr, "")
-        frictionvalue = getattr(cls, frictionvalue_attr, "")
+        frictionid = values.get(frictionid_attr) or ""
+        frictiontype = values.get(frictiontype_attr) or ""
+        frictionvalue = values.get(frictionvalue_attr) or ""
 
         if frictionid == "":
             if frictiontype == "" or frictionvalue == "":
@@ -391,7 +390,7 @@ class CircleCrsDef(CrossSectionDefinition):
             dict: Dictionary of validated values.
         """
         if CrossSectionDefinition._validate_friction_specification(
-            cls, values, "frictionid", "frictiontype", "frictionvalue"
+            values, "frictionid", "frictiontype", "frictionvalue"
         ):
             return values
 

--- a/hydrolib/core/io/ini/models.py
+++ b/hydrolib/core/io/ini/models.py
@@ -252,6 +252,9 @@ class CrossSectionDefinition(INIBasedModel):
     type: str = Field(alias="type")
     thalweg: Optional[float]
 
+    def _get_identifier(self, data: dict) -> Optional[str]:
+        return data["id"]
+
     @classmethod
     def _duplicate_keys_as_list(cls):
         return True
@@ -676,8 +679,8 @@ class YZCrsDef(CrossSectionDefinition):
     _check_frictlist_length1 = make_list_length_root_validator(
         "frictionpositions",
         length_name="sectioncount",
-        length_incr=1,  # 1 extra for frictionpositions
         id_name="id",
+        length_incr=1,  # 1 extra for frictionpositions
     )
 
     _friction_validator = CrossSectionDefinition._get_friction_root_validator(

--- a/hydrolib/core/io/ini/models.py
+++ b/hydrolib/core/io/ini/models.py
@@ -571,6 +571,18 @@ class ZWCrsDef(CrossSectionDefinition):
         delimiter=" ",
     )
 
+    _check_list_length = make_list_length_root_validator(
+        "levels",
+        "flowwidths",
+        "totalwidths",
+        length_name="numlevels",
+        id_name="id",
+    )
+
+    _friction_validator = CrossSectionDefinition._get_friction_root_validator(
+        "frictionid", "frictiontype", "frictionvalue"
+    )
+
 
 class YZCrsDef(CrossSectionDefinition):
     class Comments(CrossSectionDefinition.Comments):
@@ -629,7 +641,7 @@ class YZCrsDef(CrossSectionDefinition):
     zcoordinates: List[float] = Field(alias="zCoordinates")
     conveyance: Optional[str] = Field("segmented")
     sectioncount: Optional[int] = Field(1, alias="sectionCount")
-    frictionpositions: List[float] = Field(alias="frictionPositions")
+    frictionpositions: Optional[List[float]] = Field(alias="frictionPositions")
     frictionids: Optional[List[str]] = Field(alias="frictionIds")
     frictiontypes: Optional[List[str]] = Field(alias="frictionTypes")
     frictionvalues: Optional[List[float]] = Field(alias="frictionValues")
@@ -645,6 +657,31 @@ class YZCrsDef(CrossSectionDefinition):
         "frictionids",
         "frictiontypes",
         delimiter=";",
+    )
+
+    _check_yzlist_length = make_list_length_root_validator(
+        "ycoordinates",
+        "zcoordinates",
+        length_name="yzcount",
+        id_name="id",
+    )
+
+    _check_frictlist_length = make_list_length_root_validator(
+        "frictionids",
+        "frictiontypes",
+        "frictionvalues",
+        length_name="sectioncount",
+        id_name="id",
+    )
+    _check_frictlist_length1 = make_list_length_root_validator(
+        "frictionpositions",
+        length_name="sectioncount",
+        length_incr=1,  # 1 extra for frictionpositions
+        id_name="id",
+    )
+
+    _friction_validator = CrossSectionDefinition._get_friction_root_validator(
+        "frictionids", "frictiontypes", "frictionvalues"
     )
 
 
@@ -716,6 +753,19 @@ class XYZCrsDef(YZCrsDef, CrossSectionDefinition):
                 f"xyz cross section definition should not contain field yzCount (rather: xyzCount), current value: {yzcount_value}."
             )
         return field_value
+
+    _check_yzlist_length = make_list_length_root_validator(
+        "ycoordinates",
+        "zcoordinates",
+        length_name="xyzcount",
+        id_name="id",
+    )
+
+    _check_xlist_length = make_list_length_root_validator(
+        "xcoordinates",
+        length_name="xyzcount",
+        id_name="id",
+    )
 
 
 class CrossSection(INIBasedModel):

--- a/hydrolib/core/io/ini/models.py
+++ b/hydrolib/core/io/ini/models.py
@@ -25,6 +25,7 @@ from hydrolib.core.io.base import DummySerializer
 from hydrolib.core.io.ini.util import (
     get_from_subclass_defaults,
     get_split_string_on_delimiter_validator,
+    make_list_length_validator,
 )
 
 from .io_models import (
@@ -540,6 +541,20 @@ class ZWRiverCrsDef(CrossSectionDefinition):
         "frictiontypes",
         delimiter=";",
     )
+
+    @root_validator
+    @classmethod
+    def check_lists(cls, values: dict) -> dict:
+        _check_list_length = make_list_length_validator(
+            "levels",
+            "flowwidths",
+            "totalwidths",
+            length=values["numlevels"],
+            length_name="numlevels",
+            annotation=f"id = {values['id']}",
+        )
+
+        return values
 
     @root_validator
     @classmethod

--- a/hydrolib/core/io/ini/models.py
+++ b/hydrolib/core/io/ini/models.py
@@ -424,6 +424,26 @@ class RectangleCrsDef(CrossSectionDefinition):
     frictiontype: Optional[str] = Field(alias="frictionType")
     frictionvalue: Optional[float] = Field(alias="frictionValue")
 
+    @root_validator
+    @classmethod
+    def check_friction(cls, values: dict) -> dict:
+        """
+        Verifies whether the crosssection definition has a valid friction specification.
+
+        Args:
+            values (dict): Dictionary of validated values to create a CrossSectionDefinition subclass.
+
+        Raises:
+            ValueError: When the values dictionary does not contain valid friction keys.
+
+        Returns:
+            dict: Dictionary of validated values.
+        """
+        if CrossSectionDefinition._validate_friction_specification(
+            values, "frictionid", "frictiontype", "frictionvalue"
+        ):
+            return values
+
 
 class ZWRiverCrsDef(CrossSectionDefinition):
     class Comments(CrossSectionDefinition.Comments):
@@ -520,6 +540,26 @@ class ZWRiverCrsDef(CrossSectionDefinition):
         "frictiontypes",
         delimiter=";",
     )
+
+    @root_validator
+    @classmethod
+    def check_friction(cls, values: dict) -> dict:
+        """
+        Verifies whether the crosssection definition has a valid friction specification.
+
+        Args:
+            values (dict): Dictionary of validated values to create a CrossSectionDefinition subclass.
+
+        Raises:
+            ValueError: When the values dictionary does not contain valid friction keys.
+
+        Returns:
+            dict: Dictionary of validated values.
+        """
+        if CrossSectionDefinition._validate_friction_specification(
+            values, "frictionids", "frictiontypes", "frictionvalues"
+        ):
+            return values
 
 
 class ZWCrsDef(CrossSectionDefinition):

--- a/hydrolib/core/io/ini/models.py
+++ b/hydrolib/core/io/ini/models.py
@@ -520,7 +520,7 @@ class ZWRiverCrsDef(CrossSectionDefinition):
         "flowwidths",
         "totalwidths",
         length_name="numlevels",
-        annotation="id",
+        id_name="id",
     )
 
 

--- a/hydrolib/core/io/ini/util.py
+++ b/hydrolib/core/io/ini/util.py
@@ -3,7 +3,7 @@
 from enum import Enum
 from typing import Any, Type
 
-from pydantic.class_validators import validator, root_validator
+from pydantic.class_validators import root_validator, validator
 from pydantic.main import BaseModel
 
 
@@ -58,18 +58,26 @@ def make_list_validator(*field_name: str):
     return validator(*field_name, allow_reuse=True, pre=True)(split)
 
 
-def make_list_length_root_validator(*field_names, length_name: str, annotation: str):
-    """Get a validator make a list of object if a single object is passed."""
+def make_list_length_root_validator(*field_names, length_name: str, id_name: str):
+    """
+    Get a root_validator that checks the correct length of several list fields in an object.
+
+    Args:
+        *field_names (str): names of the instance variables that are a list and need checking.
+        length_name (str): name of the instance variable that stores the expected length.
+        id_name (str): name of the ``id`` instance variable that will be printed in an error message string.
+    """
 
     def validate_correct_length(cls, values):
-        length = int(values.get("length_name", "0"))
+        length = int(values.get(length_name, "0"))
 
         for field_name in field_names:
-            field = values.get(field_name) or []
-            if not (isinstance(field, list) and len(field) == length):
-
+            field = values.get(field_name)
+            if field is not None and not (
+                isinstance(field, list) and len(field) == length
+            ):
                 raise ValueError(
-                    f"Number of values for {field_name} should be equal to the {length_name} value ({annotation})."
+                    f"Number of values for {field_name} should be equal to the {length_name} value ({id_name}={values[id_name]})."
                 )
         return values
 

--- a/hydrolib/core/io/ini/util.py
+++ b/hydrolib/core/io/ini/util.py
@@ -59,7 +59,7 @@ def make_list_validator(*field_name: str):
 
 
 def make_list_length_root_validator(
-    *field_names, length_name: str, id_name: str, length_incr: int = 0
+    *field_names, length_name: str, length_incr: int = 0
 ):
     """
     Get a root_validator that checks the correct length of several list fields in an object.
@@ -68,7 +68,6 @@ def make_list_length_root_validator(
         *field_names (str): names of the instance variables that are a list and need checking.
         length_name (str): name of the instance variable that stores the expected length.
         length_incr (int): Optional extra increment of length value (e.g., to have +1 extra value in lists).
-        id_name (str): name of the ``id`` instance variable that will be printed in an error message string.
     """
 
     def validate_correct_length(cls, values):
@@ -86,7 +85,7 @@ def make_list_length_root_validator(
                 isinstance(field, list) and len(field) == length
             ):
                 raise ValueError(
-                    f"Number of values for {field_name} should be equal to the {length_name} value{incrstring} ({id_name}={values[id_name]})."
+                    f"Number of values for {field_name} should be equal to the {length_name} value{incrstring}."
                 )
         return values
 

--- a/hydrolib/core/io/ini/util.py
+++ b/hydrolib/core/io/ini/util.py
@@ -59,7 +59,7 @@ def make_list_validator(*field_name: str):
 
 
 def make_list_length_root_validator(
-    *field_names, length_name: str, length_incr: int = 0, id_name: str
+    *field_names, length_name: str, id_name: str, length_incr: int = 0
 ):
     """
     Get a root_validator that checks the correct length of several list fields in an object.
@@ -78,6 +78,7 @@ def make_list_length_root_validator(
             return values
 
         length = length + length_incr
+        incrstring = f" + {length_incr}" if length_incr != 0 else ""
 
         for field_name in field_names:
             field = values.get(field_name)
@@ -85,7 +86,7 @@ def make_list_length_root_validator(
                 isinstance(field, list) and len(field) == length
             ):
                 raise ValueError(
-                    f"Number of values for {field_name} should be equal to the {length_name} value ({id_name}={values[id_name]})."
+                    f"Number of values for {field_name} should be equal to the {length_name} value{incrstring} ({id_name}={values[id_name]})."
                 )
         return values
 

--- a/hydrolib/core/io/ini/util.py
+++ b/hydrolib/core/io/ini/util.py
@@ -58,6 +58,25 @@ def make_list_validator(*field_name: str):
     return validator(*field_name, allow_reuse=True, pre=True)(split)
 
 
+def make_list_length_validator(
+    *field_name, length: int, length_name: str, annotation: str
+):
+    """Get a validator make a list of object if a single object is passed."""
+
+    def has_correct_length(v: Any, length: int, length_name: str, annotation: str):
+        foo = "bar"
+        if isinstance(v, list) and len(v) == length:
+            return v
+
+        raise ValueError(
+            f"Number of values for {field_name} should be equal to the {length_name} value ({annotation})."
+        )
+
+    return validator(*field_name, allow_reuse=True, pre=True)(
+        lambda v: has_correct_length(v, length, length_name, annotation)
+    )
+
+
 def get_from_subclass_defaults(cls: Type[BaseModel], fieldname: str, value: str):
     """Gets a value that corresponds with the default field value of one of the subclasses.
 

--- a/hydrolib/core/io/ini/util.py
+++ b/hydrolib/core/io/ini/util.py
@@ -58,18 +58,26 @@ def make_list_validator(*field_name: str):
     return validator(*field_name, allow_reuse=True, pre=True)(split)
 
 
-def make_list_length_root_validator(*field_names, length_name: str, id_name: str):
+def make_list_length_root_validator(
+    *field_names, length_name: str, length_incr: int = 0, id_name: str
+):
     """
     Get a root_validator that checks the correct length of several list fields in an object.
 
     Args:
         *field_names (str): names of the instance variables that are a list and need checking.
         length_name (str): name of the instance variable that stores the expected length.
+        length_incr (int): Optional extra increment of length value (e.g., to have +1 extra value in lists).
         id_name (str): name of the ``id`` instance variable that will be printed in an error message string.
     """
 
     def validate_correct_length(cls, values):
-        length = int(values.get(length_name, "0"))
+        length = values.get(length_name)
+        if length is None:
+            # length attribute not present, possibly defer validation to a subclass.
+            return values
+
+        length = length + length_incr
 
         for field_name in field_names:
             field = values.get(field_name)

--- a/hydrolib/core/io/structure/models.py
+++ b/hydrolib/core/io/structure/models.py
@@ -220,7 +220,7 @@ class Structure(INIBasedModel):
         return exclude_set
 
     def _get_identifier(self, data: dict) -> Optional[str]:
-        return data["id"]
+        return data.get("id")
 
 
 class FlowDirection(str, Enum):

--- a/tests/data/input/dflowfm_individual_files/crsdef1.ini
+++ b/tests/data/input/dflowfm_individual_files/crsdef1.ini
@@ -1,0 +1,49 @@
+# 2021-12-02: Taken from D-Flow FM UM, C.16, example 1.
+[General]
+    fileVersion           = 3.00
+    fileType              = crossDef
+
+[Definition]
+    id                    = Prof1
+    type                  = circle
+    thalweg               = 0.0
+    diameter              = 2.0
+    frictionId            = Brick
+
+[Definition]
+    id                    = Prof1A
+    type                  = circle
+    thalweg               = 0.0
+    diameter              = 2.0
+    frictionType          = 3
+    frictionValue         = 0.1
+
+[Definition]
+    id                    = Prof2
+    type                  = zw
+    thalweg               = 0.0
+    template              = steelMouth           # template name and
+    height                = 0.950                # values used by GUI
+    r                     = 0.600
+    r1                    = 0.500
+    r2                    = 0.000
+    r3                    = 0.000
+    a                     = 0.000
+    a1                    = 0.000 
+    numLevels             = 43                   # zw levels used by kernel
+    levels                = 0.00000 0.00873 0.01746 0.02619 0.03492 0.04365 0.05238 0.06111 0.06984 0.07857 0.08730 0.09603 0.10476 0.11349 0.12222 0.13095 0.13968 0.14841 0.15714 0.16587 0.17460 0.18333 0.19206 0.20079 0.20952 0.21825 0.22698 0.23571 0.24444 0.25317 0.26190 0.27063 0.27937 0.28810 0.29683 0.30556 0.31429 0.32302 0.33175 0.34048 0.34921 0.35794 0.36667
+    flowWidths            = 0.00000 0.18605 0.26196 0.31940 0.36716 0.40863 0.44559 0.47907 0.50976 0.53814 0.56455 0.58927 0.61249 0.63439 0.65508 0.67470 0.69331 0.71102 0.72787 0.74393 0.75925 0.77388 0.78785 0.80119 0.80964 0.79011 0.76970 0.74832 0.72589 0.70231 0.67746 0.65120 0.62335 0.59367 0.56190 0.52763 0.49036 0.44934 0.40341 0.35067 0.28738 0.20396 0.00000
+    frictionId            = Steel
+
+[Definition]
+    id                    = xyzProf1
+    type                  = xyz
+    thalweg               = 283.746
+    xyzCount              = 6
+    xCoordinates          = 1920.254 1925.508 1925.508 1925.508 1930.761 1930.761
+    yCoordinates          = 1452.223 1168.526 1026.677 953.126 900.589 884.828
+    zCoordinates          = 10.000 0.004 4.994 7.585 9.445 10.000
+    conveyance            = segmented
+    sectionCount          = 3                   
+    frictionPositions     = 0.000 158.032 344.304 567.706       
+    frictionIds           = LeftBank; Main; RightBank

--- a/tests/io/test_crosssection.py
+++ b/tests/io/test_crosssection.py
@@ -188,12 +188,15 @@ def test_create_a_yzcrsdef_with_wrong_list_length_frict():
             ycoordinates=[-10, -2, 3, 12],
             zcoordinates=[1, -4, -4.1, 2],
             sectioncount=2,
+            frictionpositions=[1, 2],  # Intentional wrong list length
             frictiontypes=["Manning", "Manning"],
             frictionvalues=[0.03],  # Intentional wrong list length
         )
-    expected_message = f"Number of values for frictionvalues should be equal to the sectioncount value (id={csdefid})."
+    expected_message0 = f"Number of values for frictionvalues should be equal to the sectioncount value (id={csdefid})."
+    expected_message1 = f"Number of values for frictionpositions should be equal to the sectioncount value + 1 (id={csdefid})."
 
-    assert expected_message in str(error.value)
+    assert expected_message0 in str(error.value)
+    assert expected_message1 in str(error.value)
 
 
 def test_create_a_yzcrsdef_without_frictionspec():

--- a/tests/io/test_crosssection.py
+++ b/tests/io/test_crosssection.py
@@ -22,7 +22,7 @@ from ..utils import WrapperTest, test_data_dir
 
 
 def test_crossdef_model():
-    filepath = test_data_dir / "input/TMP_dflowfm_individual_files/crsdef1.ini"
+    filepath = test_data_dir / "input/dflowfm_individual_files/crsdef1.ini"
     m = CrossDefModel(filepath)
     assert len(m.definition) == 4
 
@@ -141,5 +141,127 @@ def test_create_a_zwrivercrsdef_without_frictionspec():
     expected_message = (
         f'Cross section with id "{csdefid}" is missing any friction specification.'
     )
+
+    assert expected_message in str(error.value)
+
+
+def test_create_a_yzcrsdef_from_scratch():
+    cd = YZCrsDef(
+        id="Prof1",
+        yzcount=4,
+        ycoordinates=[-10, -2, 3, 12],
+        zcoordinates=[1, -4, -4.1, 2],
+        frictiontypes=["Manning"],
+        frictionvalues=[0.03],
+    )
+    assert cd.id == "Prof1"
+    assert cd.type == "yz"
+    assert cd.yzcount == 4
+    assert cd.ycoordinates == [-10, -2, 3, 12]
+    assert cd.zcoordinates == [1, -4, -4.1, 2]
+    assert cd.frictiontypes == ["Manning"]
+    assert cd.frictionvalues == [0.03]
+
+
+def test_create_a_yzcrsdef_with_wrong_list_length_yz():
+    csdefid = "Prof1"
+    with pytest.raises(ValidationError) as error:
+        cd = YZCrsDef(
+            id=csdefid,
+            yzcount=4,
+            ycoordinates=[-10, -2, 3, 12],
+            zcoordinates=[1, -4, -4.1],  # Intentional wrong list length
+            frictiontypes=["Manning"],
+            frictionvalues=[0.03],
+        )
+    expected_message = f"Number of values for zcoordinates should be equal to the yzcount value (id={csdefid})."
+
+    assert expected_message in str(error.value)
+
+
+def test_create_a_yzcrsdef_with_wrong_list_length_frict():
+    csdefid = "Prof1"
+    with pytest.raises(ValidationError) as error:
+        cd = YZCrsDef(
+            id=csdefid,
+            yzcount=4,
+            ycoordinates=[-10, -2, 3, 12],
+            zcoordinates=[1, -4, -4.1, 2],
+            sectioncount=2,
+            frictiontypes=["Manning", "Manning"],
+            frictionvalues=[0.03],  # Intentional wrong list length
+        )
+    expected_message = f"Number of values for frictionvalues should be equal to the sectioncount value (id={csdefid})."
+
+    assert expected_message in str(error.value)
+
+
+def test_create_a_yzcrsdef_without_frictionspec():
+    csdefid = "Prof1"
+    with pytest.raises(ValidationError) as error:
+        cd = YZCrsDef(
+            id=csdefid,
+            yzcount=4,
+            ycoordinates=[-10, -2, 3, 12],
+            zcoordinates=[1, -4, -4.1, 2],
+        )
+    expected_message = (
+        f'Cross section with id "{csdefid}" is missing any friction specification.'
+    )
+
+    assert expected_message in str(error.value)
+
+
+def test_create_a_xyzcrsdef_from_scratch():
+    cd = XYZCrsDef(
+        id="Prof1",
+        xyzcount=4,
+        xcoordinates=[10, 20, 30, 40],
+        ycoordinates=[-10, -2, 3, 12],
+        zcoordinates=[1, -4, -4.1, 2],
+        frictiontypes=["Manning"],
+        frictionvalues=[0.03],
+    )
+    assert cd.id == "Prof1"
+    assert cd.type == "xyz"
+    assert cd.yzcount == None
+    assert cd.xyzcount == 4
+    assert cd.xcoordinates == [10, 20, 30, 40]
+    assert cd.ycoordinates == [-10, -2, 3, 12]
+    assert cd.zcoordinates == [1, -4, -4.1, 2]
+    assert cd.frictiontypes == ["Manning"]
+    assert cd.frictionvalues == [0.03]
+
+
+def test_create_a_xyzcrsdef_with_wrong_list_length_yz():
+    csdefid = "Prof1"
+    with pytest.raises(ValidationError) as error:
+        cd = XYZCrsDef(
+            id=csdefid,
+            xyzcount=4,
+            xcoordinates=[10, 20, 30, 40],
+            ycoordinates=[-10, -2, 3, 12],
+            zcoordinates=[1, -4, -4.1],  # Intentional wrong list length
+            frictiontypes=["Manning"],
+            frictionvalues=[0.03],
+        )
+    expected_message = f"Number of values for zcoordinates should be equal to the xyzcount value (id={csdefid})."
+
+    assert expected_message in str(error.value)
+
+
+def test_create_a_xyzcrsdef_with_wrong_list_length_x():
+    csdefid = "Prof1"
+    with pytest.raises(ValidationError) as error:
+        cd = XYZCrsDef(
+            id=csdefid,
+            xyzcount=4,
+            xcoordinates=[10, 20, 30],  # Intentional wrong list length
+            ycoordinates=[-10, -2, 3, 12],
+            zcoordinates=[1, -4, -4.1, 2],
+            frictiontypes=["Manning"],
+            frictionvalues=[0.03],
+        )
+    expected_message = f"Number of values for xcoordinates should be equal to the xyzcount value (id={csdefid})."
 
     assert expected_message in str(error.value)

--- a/tests/io/test_crosssection.py
+++ b/tests/io/test_crosssection.py
@@ -1,0 +1,68 @@
+import inspect
+from contextlib import nullcontext as does_not_raise
+from pathlib import Path
+from typing import Any, Callable, List, Union
+
+import pytest
+from pydantic.error_wrappers import ValidationError
+
+from hydrolib.core.io.ini.models import (
+    CircleCrsDef,
+    CrossDefModel,
+    CrossSectionDefinition,
+    RectangleCrsDef,
+    XYZCrsDef,
+    YZCrsDef,
+    ZWCrsDef,
+    ZWRiverCrsDef,
+)
+from hydrolib.core.io.ini.parser import Parser, ParserConfig
+
+from ..utils import WrapperTest, test_data_dir
+
+
+def test_crossdef_model():
+    filepath = test_data_dir / "input/TMP_dflowfm_individual_files/crsdef1.ini"
+    m = CrossDefModel(filepath)
+    assert len(m.definition) == 4
+
+    assert isinstance(m.definition[0], CircleCrsDef)
+    assert m.definition[0].id == "Prof1"
+    assert m.definition[0].thalweg == 0.0
+    assert m.definition[0].diameter == 2.0
+    assert m.definition[0].frictionid == "Brick"
+
+
+def test_create_a_circlecrsdef_from_scratch():
+    cd = CircleCrsDef(
+        id="Prof1",
+        diameter=3.14,
+        frictiontype="wallLawNikuradse",
+        frictionvalue=[1.5],
+    )
+    assert cd.id == "Prof1"
+    assert cd.diameter == 3.14
+    assert cd.frictiontype == "wallLawNikuradse"
+    assert cd.frictionvalue == 1.5
+
+
+def test_create_a_circlecrsdef_with_duplicate_frictionspec():
+    csdefid = "Prof1"
+    with pytest.raises(ValidationError) as error:
+        cd = CircleCrsDef(
+            id=csdefid,
+            diameter=3.14,
+            frictionid="Brick",
+            frictiontype="wallLawNikuradse",
+            frictionvalue=1.5,
+        )
+    expected_message = (
+        f'Cross section with id "{csdefid}" has duplicate friction specification'
+    )
+
+    assert expected_message in str(error.value)
+
+    # assert cd.id == "Prof1"
+    # assert cd.diameter == 3.14
+    # assert cd.frictiontype == "wallLawNikuradse"
+    # assert cd.frictionvalue == 1.5

--- a/tests/io/test_crosssection.py
+++ b/tests/io/test_crosssection.py
@@ -100,7 +100,11 @@ def test_create_a_zwrivercrsdef_from_scratch():
         id="Prof1",
         numlevels=2,
         levels=[-2, 3],
-        flowwidths=[11, 44],
+        flowwidths=[
+            11,
+            44,
+            12,
+        ],  # Intentional error, to try and trigger make_list_length_validator()
         frictiontypes=["Manning"],
         frictionvalues=[0.03],
     )

--- a/tests/io/test_crosssection.py
+++ b/tests/io/test_crosssection.py
@@ -41,6 +41,7 @@ def test_create_a_circlecrsdef_from_scratch():
         frictionvalue=1.5,
     )
     assert cd.id == "Prof1"
+    assert cd.type == "circle"
     assert cd.diameter == 3.14
     assert cd.frictiontype == "wallLawNikuradse"
     assert cd.frictionvalue == 1.5
@@ -58,6 +59,71 @@ def test_create_a_circlecrsdef_with_duplicate_frictionspec():
         )
     expected_message = (
         f'Cross section with id "{csdefid}" has duplicate friction specification'
+    )
+
+    assert expected_message in str(error.value)
+
+
+def test_create_a_rectanglecrsdef_from_scratch():
+    cd = RectangleCrsDef(
+        id="Prof1",
+        width=3.14,
+        height=2.718,
+        frictiontype="wallLawNikuradse",
+        frictionvalue=1.5,
+    )
+    assert cd.id == "Prof1"
+    assert cd.type == "rectangle"
+    assert cd.width == 3.14
+    assert cd.height == 2.718
+    assert cd.frictiontype == "wallLawNikuradse"
+    assert cd.frictionvalue == 1.5
+
+
+def test_create_a_rectanglecrsdef_without_frictionspec():
+    csdefid = "Prof1"
+    with pytest.raises(ValidationError) as error:
+        cd = RectangleCrsDef(
+            id=csdefid,
+            width=3.14,
+            height=2.718,
+        )
+    expected_message = (
+        f'Cross section with id "{csdefid}" is missing any friction specification.'
+    )
+
+    assert expected_message in str(error.value)
+
+
+def test_create_a_zwrivercrsdef_from_scratch():
+    cd = ZWRiverCrsDef(
+        id="Prof1",
+        numlevels=2,
+        levels=[-2, 3],
+        flowwidths=[11, 44],
+        frictiontypes=["Manning"],
+        frictionvalues=[0.03],
+    )
+    assert cd.id == "Prof1"
+    assert cd.type == "zwRiver"
+    assert cd.numlevels == 2
+    assert cd.levels == [-2, 3]
+    assert cd.flowwidths == [11, 44]
+    assert cd.frictiontypes == ["Manning"]
+    assert cd.frictionvalues == [0.03]
+
+
+def test_create_a_zwrivercrsdef_without_frictionspec():
+    csdefid = "Prof1"
+    with pytest.raises(ValidationError) as error:
+        cd = ZWRiverCrsDef(
+            id=csdefid,
+            numlevels=2,
+            levels=[-2, 3],
+            flowwidths=[11, 44],
+        )
+    expected_message = (
+        f'Cross section with id "{csdefid}" is missing any friction specification.'
     )
 
     assert expected_message in str(error.value)

--- a/tests/io/test_crosssection.py
+++ b/tests/io/test_crosssection.py
@@ -100,11 +100,7 @@ def test_create_a_zwrivercrsdef_from_scratch():
         id="Prof1",
         numlevels=2,
         levels=[-2, 3],
-        flowwidths=[
-            11,
-            44,
-            12,
-        ],  # Intentional error, to try and trigger make_list_length_validator()
+        flowwidths=[11, 44],
         frictiontypes=["Manning"],
         frictionvalues=[0.03],
     )
@@ -115,6 +111,22 @@ def test_create_a_zwrivercrsdef_from_scratch():
     assert cd.flowwidths == [11, 44]
     assert cd.frictiontypes == ["Manning"]
     assert cd.frictionvalues == [0.03]
+
+
+def test_create_a_zwrivercrsdef_with_wrong_list_lengths():
+    csdefid = "Prof1"
+    with pytest.raises(ValidationError) as error:
+        cd = ZWRiverCrsDef(
+            id=csdefid,
+            numlevels=2,
+            levels=[-2, 3, 13],  # Intentional wrong list length
+            flowwidths=[11, 44],
+            frictiontypes=["Manning"],
+            frictionvalues=[0.03],
+        )
+    expected_message = f"Number of values for levels should be equal to the numlevels value (id={csdefid})."
+
+    assert expected_message in str(error.value)
 
 
 def test_create_a_zwrivercrsdef_without_frictionspec():

--- a/tests/io/test_crosssection.py
+++ b/tests/io/test_crosssection.py
@@ -38,7 +38,7 @@ def test_create_a_circlecrsdef_from_scratch():
         id="Prof1",
         diameter=3.14,
         frictiontype="wallLawNikuradse",
-        frictionvalue=[1.5],
+        frictionvalue=1.5,
     )
     assert cd.id == "Prof1"
     assert cd.diameter == 3.14
@@ -61,8 +61,3 @@ def test_create_a_circlecrsdef_with_duplicate_frictionspec():
     )
 
     assert expected_message in str(error.value)
-
-    # assert cd.id == "Prof1"
-    # assert cd.diameter == 3.14
-    # assert cd.frictiontype == "wallLawNikuradse"
-    # assert cd.frictionvalue == 1.5

--- a/tests/io/test_crosssection.py
+++ b/tests/io/test_crosssection.py
@@ -21,250 +21,235 @@ from hydrolib.core.io.ini.parser import Parser, ParserConfig
 from ..utils import WrapperTest, test_data_dir
 
 
-def test_crossdef_model():
-    filepath = test_data_dir / "input/dflowfm_individual_files/crsdef1.ini"
-    m = CrossDefModel(filepath)
-    assert len(m.definition) == 4
+class TestCrossSection:
+    def test_crossdef_model(self):
+        filepath = test_data_dir / "input/dflowfm_individual_files/crsdef1.ini"
+        m = CrossDefModel(filepath)
+        assert len(m.definition) == 4
 
-    assert isinstance(m.definition[0], CircleCrsDef)
-    assert m.definition[0].id == "Prof1"
-    assert m.definition[0].thalweg == 0.0
-    assert m.definition[0].diameter == 2.0
-    assert m.definition[0].frictionid == "Brick"
+        assert isinstance(m.definition[0], CircleCrsDef)
+        assert m.definition[0].id == "Prof1"
+        assert m.definition[0].thalweg == 0.0
+        assert m.definition[0].diameter == 2.0
+        assert m.definition[0].frictionid == "Brick"
 
+    circledef = {
+        "id": "Prof1",
+        "diameter": 3.14,
+        "frictiontype": "wallLawNikuradse",
+        "frictionvalue": 1.5,
+    }
 
-def test_create_a_circlecrsdef_from_scratch():
-    cd = CircleCrsDef(
-        id="Prof1",
-        diameter=3.14,
-        frictiontype="wallLawNikuradse",
-        frictionvalue=1.5,
+    rectangledef = {
+        "id": "Prof1",
+        "width": 3.14,
+        "height": 2.718,
+        "frictiontype": "wallLawNikuradse",
+        "frictionvalue": 1.5,
+    }
+
+    zwdef = {
+        "id": "Prof1",
+        "numlevels": 2,
+        "levels": [-2, 3],
+        "flowwidths": [11, 44],
+        "frictiontype": "Manning",
+        "frictionvalue": 0.03,
+    }
+
+    zwriverdef = {
+        "id": "Prof1",
+        "numlevels": 2,
+        "levels": [-2, 3],
+        "flowwidths": [11, 44],
+        "frictiontypes": ["Manning"],
+        "frictionvalues": [0.03],
+    }
+
+    yzdef = {
+        "id": "Prof1",
+        "yzcount": 4,
+        "ycoordinates": [-10, -2, 3, 12],
+        "zcoordinates": [1, -4, -4.1, 2],
+        "frictiontypes": ["Manning"],
+        "frictionvalues": [0.03],
+    }
+
+    xyzdef = {
+        "id": "Prof1",
+        "xyzcount": 4,
+        "xcoordinates": [10, 20, 30, 40],
+        "ycoordinates": [-10, -2, 3, 12],
+        "zcoordinates": [1, -4, -4.1, 2],
+        "frictiontypes": ["Manning"],
+        "frictionvalues": [0.03],
+    }
+
+    @pytest.mark.parametrize(
+        "crscls, crsdict, expected_type",
+        [
+            pytest.param(CircleCrsDef, circledef, "circle"),
+            pytest.param(RectangleCrsDef, rectangledef, "rectangle"),
+            pytest.param(ZWCrsDef, zwdef, "zw"),
+            pytest.param(ZWRiverCrsDef, zwriverdef, "zwRiver"),
+            pytest.param(YZCrsDef, yzdef, "yz"),
+            pytest.param(XYZCrsDef, xyzdef, "xyz"),
+        ],
     )
-    assert cd.id == "Prof1"
-    assert cd.type == "circle"
-    assert cd.diameter == 3.14
-    assert cd.frictiontype == "wallLawNikuradse"
-    assert cd.frictionvalue == 1.5
+    def test_create_a_crsdef_from_scratchs(
+        self, crscls, crsdict: dict, expected_type: str
+    ):
+        """
+        Test that creates a cross section definition from dict, and asserts that
+        all fields are correcty set in the object.
 
+        Args:
+            crscls: the subclass of CrossSectionDefinition that will be instantiated.
+            crsdict: the key-value pairs for the class's attributes.
+            expected_type: the expected value of the object's type attribute.
+        """
+        cd = crscls(**crsdict)
+        assert cd.type == expected_type
+        for key, value in crsdict.items():
+            assert getattr(cd, key) == value
 
-def test_create_a_circlecrsdef_with_duplicate_frictionspec():
-    csdefid = "Prof1"
-    with pytest.raises(ValidationError) as error:
-        cd = CircleCrsDef(
-            id=csdefid,
-            diameter=3.14,
-            frictionid="Brick",
-            frictiontype="wallLawNikuradse",
-            frictionvalue=1.5,
+    def test_create_a_circlecrsdef_with_duplicate_frictionspec(self):
+        csdefid = "Prof1"
+        with pytest.raises(ValidationError) as error:
+            _ = CircleCrsDef(
+                id=csdefid,
+                diameter=3.14,
+                frictionid="Brick",
+                frictiontype="wallLawNikuradse",
+                frictionvalue=1.5,
+            )
+        expected_message = f"Cross section has duplicate friction specification"
+
+        assert expected_message in str(error.value)
+
+    def test_create_a_rectanglecrsdef_without_frictionspec(self):
+        csdefid = "Prof1"
+        with pytest.raises(ValidationError) as error:
+            _ = RectangleCrsDef(
+                id=csdefid,
+                width=3.14,
+                height=2.718,
+            )
+        expected_message = f"Cross section is missing any friction specification."
+
+        assert expected_message in str(error.value)
+
+    def test_create_a_zwrivercrsdef_with_wrong_list_lengths(self):
+        csdefid = "Prof1"
+        with pytest.raises(ValidationError) as error:
+            _ = ZWRiverCrsDef(
+                id=csdefid,
+                numlevels=2,
+                levels=[-2, 3, 13],  # Intentional wrong list length
+                flowwidths=[11, 44],
+                frictiontypes=["Manning"],
+                frictionvalues=[0.03],
+            )
+        expected_message = (
+            f"Number of values for levels should be equal to the numlevels value."
         )
-    expected_message = (
-        f'Cross section with id "{csdefid}" has duplicate friction specification'
-    )
 
-    assert expected_message in str(error.value)
+        assert expected_message in str(error.value)
 
+    def test_create_a_zwrivercrsdef_without_frictionspec(self):
+        csdefid = "Prof1"
+        with pytest.raises(ValidationError) as error:
+            _ = ZWRiverCrsDef(
+                id=csdefid,
+                numlevels=2,
+                levels=[-2, 3],
+                flowwidths=[11, 44],
+            )
+        expected_message = f"Cross section is missing any friction specification."
 
-def test_create_a_rectanglecrsdef_from_scratch():
-    cd = RectangleCrsDef(
-        id="Prof1",
-        width=3.14,
-        height=2.718,
-        frictiontype="wallLawNikuradse",
-        frictionvalue=1.5,
-    )
-    assert cd.id == "Prof1"
-    assert cd.type == "rectangle"
-    assert cd.width == 3.14
-    assert cd.height == 2.718
-    assert cd.frictiontype == "wallLawNikuradse"
-    assert cd.frictionvalue == 1.5
+        assert expected_message in str(error.value)
 
-
-def test_create_a_rectanglecrsdef_without_frictionspec():
-    csdefid = "Prof1"
-    with pytest.raises(ValidationError) as error:
-        cd = RectangleCrsDef(
-            id=csdefid,
-            width=3.14,
-            height=2.718,
+    def test_create_a_yzcrsdef_with_wrong_list_length_yz(self):
+        csdefid = "Prof1"
+        with pytest.raises(ValidationError) as error:
+            _ = YZCrsDef(
+                id=csdefid,
+                yzcount=4,
+                ycoordinates=[-10, -2, 3, 12],
+                zcoordinates=[1, -4, -4.1],  # Intentional wrong list length
+                frictiontypes=["Manning"],
+                frictionvalues=[0.03],
+            )
+        expected_message = (
+            f"Number of values for zcoordinates should be equal to the yzcount value."
         )
-    expected_message = (
-        f'Cross section with id "{csdefid}" is missing any friction specification.'
-    )
 
-    assert expected_message in str(error.value)
+        assert expected_message in str(error.value)
 
+    def test_create_a_yzcrsdef_with_wrong_list_length_frict(self):
+        csdefid = "Prof1"
+        with pytest.raises(ValidationError) as error:
+            _ = YZCrsDef(
+                id=csdefid,
+                yzcount=4,
+                ycoordinates=[-10, -2, 3, 12],
+                zcoordinates=[1, -4, -4.1, 2],
+                sectioncount=2,
+                frictionpositions=[1, 2],  # Intentional wrong list length
+                frictiontypes=["Manning", "Manning"],
+                frictionvalues=[0.03],  # Intentional wrong list length
+            )
+        expected_message0 = f"Number of values for frictionvalues should be equal to the sectioncount value."
+        expected_message1 = f"Number of values for frictionpositions should be equal to the sectioncount value + 1."
 
-def test_create_a_zwrivercrsdef_from_scratch():
-    cd = ZWRiverCrsDef(
-        id="Prof1",
-        numlevels=2,
-        levels=[-2, 3],
-        flowwidths=[11, 44],
-        frictiontypes=["Manning"],
-        frictionvalues=[0.03],
-    )
-    assert cd.id == "Prof1"
-    assert cd.type == "zwRiver"
-    assert cd.numlevels == 2
-    assert cd.levels == [-2, 3]
-    assert cd.flowwidths == [11, 44]
-    assert cd.frictiontypes == ["Manning"]
-    assert cd.frictionvalues == [0.03]
+        assert expected_message0 in str(error.value)
+        assert expected_message1 in str(error.value)
 
+    def test_create_a_yzcrsdef_without_frictionspec(self):
+        csdefid = "Prof1"
+        with pytest.raises(ValidationError) as error:
+            _ = YZCrsDef(
+                id=csdefid,
+                yzcount=4,
+                ycoordinates=[-10, -2, 3, 12],
+                zcoordinates=[1, -4, -4.1, 2],
+            )
+        expected_message = f"Cross section is missing any friction specification."
 
-def test_create_a_zwrivercrsdef_with_wrong_list_lengths():
-    csdefid = "Prof1"
-    with pytest.raises(ValidationError) as error:
-        cd = ZWRiverCrsDef(
-            id=csdefid,
-            numlevels=2,
-            levels=[-2, 3, 13],  # Intentional wrong list length
-            flowwidths=[11, 44],
-            frictiontypes=["Manning"],
-            frictionvalues=[0.03],
+        assert expected_message in str(error.value)
+
+    def test_create_a_xyzcrsdef_with_wrong_list_length_yz(self):
+        csdefid = "Prof1"
+        with pytest.raises(ValidationError) as error:
+            _ = XYZCrsDef(
+                id=csdefid,
+                xyzcount=4,
+                xcoordinates=[10, 20, 30, 40],
+                ycoordinates=[-10, -2, 3, 12],
+                zcoordinates=[1, -4, -4.1],  # Intentional wrong list length
+                frictiontypes=["Manning"],
+                frictionvalues=[0.03],
+            )
+        expected_message = (
+            f"Number of values for zcoordinates should be equal to the xyzcount value."
         )
-    expected_message = f"Number of values for levels should be equal to the numlevels value (id={csdefid})."
 
-    assert expected_message in str(error.value)
+        assert expected_message in str(error.value)
 
-
-def test_create_a_zwrivercrsdef_without_frictionspec():
-    csdefid = "Prof1"
-    with pytest.raises(ValidationError) as error:
-        cd = ZWRiverCrsDef(
-            id=csdefid,
-            numlevels=2,
-            levels=[-2, 3],
-            flowwidths=[11, 44],
+    def test_create_a_xyzcrsdef_with_wrong_list_length_x(self):
+        csdefid = "Prof1"
+        with pytest.raises(ValidationError) as error:
+            _ = XYZCrsDef(
+                id=csdefid,
+                xyzcount=4,
+                xcoordinates=[10, 20, 30],  # Intentional wrong list length
+                ycoordinates=[-10, -2, 3, 12],
+                zcoordinates=[1, -4, -4.1, 2],
+                frictiontypes=["Manning"],
+                frictionvalues=[0.03],
+            )
+        expected_message = (
+            f"Number of values for xcoordinates should be equal to the xyzcount value."
         )
-    expected_message = (
-        f'Cross section with id "{csdefid}" is missing any friction specification.'
-    )
 
-    assert expected_message in str(error.value)
-
-
-def test_create_a_yzcrsdef_from_scratch():
-    cd = YZCrsDef(
-        id="Prof1",
-        yzcount=4,
-        ycoordinates=[-10, -2, 3, 12],
-        zcoordinates=[1, -4, -4.1, 2],
-        frictiontypes=["Manning"],
-        frictionvalues=[0.03],
-    )
-    assert cd.id == "Prof1"
-    assert cd.type == "yz"
-    assert cd.yzcount == 4
-    assert cd.ycoordinates == [-10, -2, 3, 12]
-    assert cd.zcoordinates == [1, -4, -4.1, 2]
-    assert cd.frictiontypes == ["Manning"]
-    assert cd.frictionvalues == [0.03]
-
-
-def test_create_a_yzcrsdef_with_wrong_list_length_yz():
-    csdefid = "Prof1"
-    with pytest.raises(ValidationError) as error:
-        cd = YZCrsDef(
-            id=csdefid,
-            yzcount=4,
-            ycoordinates=[-10, -2, 3, 12],
-            zcoordinates=[1, -4, -4.1],  # Intentional wrong list length
-            frictiontypes=["Manning"],
-            frictionvalues=[0.03],
-        )
-    expected_message = f"Number of values for zcoordinates should be equal to the yzcount value (id={csdefid})."
-
-    assert expected_message in str(error.value)
-
-
-def test_create_a_yzcrsdef_with_wrong_list_length_frict():
-    csdefid = "Prof1"
-    with pytest.raises(ValidationError) as error:
-        cd = YZCrsDef(
-            id=csdefid,
-            yzcount=4,
-            ycoordinates=[-10, -2, 3, 12],
-            zcoordinates=[1, -4, -4.1, 2],
-            sectioncount=2,
-            frictionpositions=[1, 2],  # Intentional wrong list length
-            frictiontypes=["Manning", "Manning"],
-            frictionvalues=[0.03],  # Intentional wrong list length
-        )
-    expected_message0 = f"Number of values for frictionvalues should be equal to the sectioncount value (id={csdefid})."
-    expected_message1 = f"Number of values for frictionpositions should be equal to the sectioncount value + 1 (id={csdefid})."
-
-    assert expected_message0 in str(error.value)
-    assert expected_message1 in str(error.value)
-
-
-def test_create_a_yzcrsdef_without_frictionspec():
-    csdefid = "Prof1"
-    with pytest.raises(ValidationError) as error:
-        cd = YZCrsDef(
-            id=csdefid,
-            yzcount=4,
-            ycoordinates=[-10, -2, 3, 12],
-            zcoordinates=[1, -4, -4.1, 2],
-        )
-    expected_message = (
-        f'Cross section with id "{csdefid}" is missing any friction specification.'
-    )
-
-    assert expected_message in str(error.value)
-
-
-def test_create_a_xyzcrsdef_from_scratch():
-    cd = XYZCrsDef(
-        id="Prof1",
-        xyzcount=4,
-        xcoordinates=[10, 20, 30, 40],
-        ycoordinates=[-10, -2, 3, 12],
-        zcoordinates=[1, -4, -4.1, 2],
-        frictiontypes=["Manning"],
-        frictionvalues=[0.03],
-    )
-    assert cd.id == "Prof1"
-    assert cd.type == "xyz"
-    assert cd.yzcount == None
-    assert cd.xyzcount == 4
-    assert cd.xcoordinates == [10, 20, 30, 40]
-    assert cd.ycoordinates == [-10, -2, 3, 12]
-    assert cd.zcoordinates == [1, -4, -4.1, 2]
-    assert cd.frictiontypes == ["Manning"]
-    assert cd.frictionvalues == [0.03]
-
-
-def test_create_a_xyzcrsdef_with_wrong_list_length_yz():
-    csdefid = "Prof1"
-    with pytest.raises(ValidationError) as error:
-        cd = XYZCrsDef(
-            id=csdefid,
-            xyzcount=4,
-            xcoordinates=[10, 20, 30, 40],
-            ycoordinates=[-10, -2, 3, 12],
-            zcoordinates=[1, -4, -4.1],  # Intentional wrong list length
-            frictiontypes=["Manning"],
-            frictionvalues=[0.03],
-        )
-    expected_message = f"Number of values for zcoordinates should be equal to the xyzcount value (id={csdefid})."
-
-    assert expected_message in str(error.value)
-
-
-def test_create_a_xyzcrsdef_with_wrong_list_length_x():
-    csdefid = "Prof1"
-    with pytest.raises(ValidationError) as error:
-        cd = XYZCrsDef(
-            id=csdefid,
-            xyzcount=4,
-            xcoordinates=[10, 20, 30],  # Intentional wrong list length
-            ycoordinates=[-10, -2, 3, 12],
-            zcoordinates=[1, -4, -4.1, 2],
-            frictiontypes=["Manning"],
-            frictionvalues=[0.03],
-        )
-    expected_message = f"Number of values for xcoordinates should be equal to the xyzcount value (id={csdefid})."
-
-    assert expected_message in str(error.value)
+        assert expected_message in str(error.value)


### PR DESCRIPTION
Fixes #124.

Any idea on how to reduce copy-pasted code in my commits?
I did split off a reusable function CrossSectionDefinition._validate_friction_specification(), but the check_friction validators in CircleCrsDef, RectangleCrsDef and ZwRiverCrsDef are really copy-pasted, and the unit tests in test_crosssection.py are also really quite similar.
I still have three more subclasses to go...