### PR TITLE
#77 Improve validation of optionally required fields in weir structure

### DIFF
--- a/hydrolib/core/io/structure/models.py
+++ b/hydrolib/core/io/structure/models.py
@@ -253,7 +253,8 @@ class Weir(Structure):
     comments: Comments = Comments()
 
     type: Literal["weir"] = Field("weir", alias="type")
-    allowedflowdir: FlowDirection = Field(alias="allowedFlowDir")
+    allowedflowdir: Optional[FlowDirection] = Field(
+        FlowDirection.both, alias="allowedFlowDir")
 
     crestlevel: Union[float, Path] = Field(alias="crestLevel")
     crestwidth: Optional[float] = Field(None, alias="crestWidth")

--- a/hydrolib/core/io/structure/models.py
+++ b/hydrolib/core/io/structure/models.py
@@ -254,7 +254,8 @@ class Weir(Structure):
 
     type: Literal["weir"] = Field("weir", alias="type")
     allowedflowdir: Optional[FlowDirection] = Field(
-        FlowDirection.both, alias="allowedFlowDir")
+        FlowDirection.both, alias="allowedFlowDir"
+    )
 
     crestlevel: Union[float, Path] = Field(alias="crestLevel")
     crestwidth: Optional[float] = Field(None, alias="crestWidth")

--- a/tests/io/test_structure.py
+++ b/tests/io/test_structure.py
@@ -1260,17 +1260,16 @@ structure_id -> {limitflow}\n  \
         assert structure.limitflowneg == None
 
     def _create_required_orifice_values(self) -> dict:
-        return dict(
-            id="structure_id",
-            name="structure_name",
-            type="orifice",
-            branchid="branch_id",
-            chainage="1.23",
+        orifice_values = dict(
             crestlevel="2.34",
             gateloweredgelevel="4.56",
             corrcoeff="5.67",
             usevelocityheight="true",
         )
+
+        orifice_values.update(create_structure_values())
+
+        return orifice_values
 
     def _create_orifice_values(self) -> dict:
         orifice_values = dict(
@@ -1475,3 +1474,13 @@ class TestWeir:
         )
 
         assert structure.allowedflowdir == expected
+
+
+def create_structure_values() -> dict:
+    return dict(
+        id="structure_id",
+        name="structure_name",
+        type="orifice",
+        branchid="branch_id",
+        chainage="1.23",
+    )

--- a/tests/io/test_structure.py
+++ b/tests/io/test_structure.py
@@ -1289,26 +1289,20 @@ structure_id -> {limitflow}\n  \
 class TestWeir:
     def test_create_a_weir_from_scratch(self):
         weir = Weir(
-            id="w003",
-            name="W003",
-            branchid="B1",
-            chainage=5.0,
-            allowedflowdir=FlowDirection.none,
-            crestlevel=0.5,
-            usevelocityheight=False,
+            **self._create_weir_values(),
             comments=Weir.Comments(
                 name="W stands for weir, 003 because we expect to have at most 999 weirs"
             ),
         )
 
-        assert weir.id == "w003"
-        assert weir.name == "W003"
-        assert weir.branchid == "B1"
-        assert weir.chainage == 5.0
-        assert weir.allowedflowdir == FlowDirection.none
-        assert weir.crestlevel == 0.5
-        assert weir.crestwidth == None
-        assert weir.usevelocityheight == False
+        assert weir.id == "structure_id"
+        assert weir.name == "structure_name"
+        assert weir.branchid == "branch_id"
+        assert weir.chainage == 1.23
+        assert weir.allowedflowdir == FlowDirection.positive
+        assert weir.crestlevel == 2.34
+        assert weir.crestwidth == 3.45
+        assert weir.usevelocityheight == True
         assert (
             weir.comments.name
             == "W stands for weir, 003 because we expect to have at most 999 weirs"
@@ -1317,30 +1311,12 @@ class TestWeir:
         assert weir.comments.id == uniqueid_str
 
     def test_id_comment_has_correct_default(self):
-        weir = Weir(
-            id="weir_id",
-            name="W001",
-            branchid="branch",
-            chainage=3.0,
-            allowedflowdir=FlowDirection.positive,
-            crestlevel=10.5,
-            crestwidth=None,
-            usevelocityheight=False,
-        )
+        weir = Weir(**self._create_weir_values())
 
         assert weir.comments.id == uniqueid_str
 
     def test_add_comment_to_weir(self):
-        weir = Weir(
-            id="weir_id",
-            name="W001",
-            branchid="branch",
-            chainage=3.0,
-            allowedflowdir=FlowDirection.positive,
-            crestlevel=10.5,
-            crestwidth=None,
-            usevelocityheight=False,
-        )
+        weir = Weir(**self._create_weir_values())
 
         weir.comments.usevelocityheight = "a different value"
         assert weir.comments.usevelocityheight == "a different value"
@@ -1466,11 +1442,8 @@ class TestWeir:
     )
     def test_weir_parses_flowdirection_case_insensitive(self, input, expected):
         structure = Weir(
+            **self._create_required_weir_values(),
             allowedflowdir=input,
-            id="strucid",
-            branchid="branchid",
-            chainage="1",
-            crestlevel="1",
         )
 
         assert structure.allowedflowdir == expected

--- a/tests/io/test_structure.py
+++ b/tests/io/test_structure.py
@@ -1267,7 +1267,7 @@ structure_id -> {limitflow}\n  \
             usevelocityheight="true",
         )
 
-        orifice_values.update(create_structure_values())
+        orifice_values.update(create_structure_values("orifice"))
 
         return orifice_values
 
@@ -1475,12 +1475,37 @@ class TestWeir:
 
         assert structure.allowedflowdir == expected
 
+    def test_optional_fields_have_correct_defaults(self):
+        structure = Weir(**self._create_required_weir_values())
 
-def create_structure_values() -> dict:
+        assert structure.allowedflowdir == FlowDirection.both
+        assert structure.crestwidth == None
+
+    def _create_required_weir_values(self) -> dict:
+        weir_values = dict(
+            crestlevel="2.34",
+            corrcoeff="5.67",
+            usevelocityheight="true",
+        )
+
+        weir_values.update(create_structure_values("weir"))
+        return weir_values
+
+    def _create_weir_values(self) -> dict:
+        weir_values = dict(
+            allowedflowdir="positive",
+            crestwidth="3.45",
+        )
+
+        weir_values.update(self._create_required_weir_values())
+        return weir_values
+
+
+def create_structure_values(type: str) -> dict:
     return dict(
         id="structure_id",
         name="structure_name",
-        type="orifice",
+        type=type,
         branchid="branch_id",
         chainage="1.23",
     )


### PR DESCRIPTION
Moved all the weir tests to TestWeir class to keep them bundled.
Made the  `allowedFlowDir` optional and added the default `both`
Added a test for the default fields.