### PR TITLE
Fix key-value-comment parsing

### DIFF
--- a/hydrolib/core/io/ini/parser.py
+++ b/hydrolib/core/io/ini/parser.py
@@ -224,8 +224,11 @@ class Parser:
         self._current_section.add_comment(comment, self._line_index)  # type: ignore
 
     def _handle_property(self, line: str) -> None:
-        comment, line = self._retrieve_property_comment(line.strip())
-        key, value = self._retrieve_key_value(line)
+        key, valuepart = self._retrieve_key_value(line)
+        if valuepart is not None:
+            comment, value = self._retrieve_property_comment(valuepart.strip())
+        else:
+            comment, value = None, None
 
         prop = Property(key=key, value=value, comment=comment)
         self._current_section.add_property(prop)  # type: ignore
@@ -268,23 +271,29 @@ class Parser:
             numhash = line.count(self._config.comment_delimiter)
             if numhash == 1:
                 # normal value, simple comment: "key =  somevalue # and a comment "
-                return parts[-1].strip(), parts[0].strip()
+                comment = parts[-1]
+                value = parts[0]
             elif line.startswith(self._config.comment_delimiter):
                 # hashed value, possible with comment: "key = #somevalue# ..."
-                return (
-                    self._config.comment_delimiter.join(parts[3:]).strip()
+                comment = (
+                    self._config.comment_delimiter.join(parts[3:])
                     if numhash >= 3
-                    else None,
-                    self._config.comment_delimiter.join(parts[0:3]).strip(),
+                    else ""
                 )
+
+                value = self._config.comment_delimiter.join(parts[0:3])
             else:
                 # normal value, comment with maybe more hashes: "key = somevalue #This is comment #2, or two "
-                return (
-                    self._config.comment_delimiter.join(parts[1:]).strip(),
-                    parts[0].strip(),
-                )
+                comment = self._config.comment_delimiter.join(parts[1:])
+                value = parts[0]
         else:
-            return None, line.strip()
+            comment = ""
+            value = line
+
+        return (
+            comment if len(comment := comment.strip()) > 0 else None,
+            value if len(value := value.strip()) > 0 else None,
+        )
 
     def _retrieve_key_value(self, line: str) -> Tuple[str, Optional[str]]:
         if "=" in line:


### PR DESCRIPTION
Fixes #147 partially (and improves #121):
Testcase tests\data\input\e02\f101_1D-boundaries\c01_steady-state-flow\roughness-Main.ini
showed that:
    frictionId            = #Main#
was not correctly parsed. For the simple reason that the calling order of _retrieve_property_comment and _retrieve_key_value was wrong.
At the same time I fixed returning of None's from _retrieve_property_comment, now consistent with None-behavior of _retrieve_key_value.