### PR TITLE
Adjust datablock type of DataBlockINIBasedModel

### DIFF
--- a/hydrolib/core/io/bc/models.py
+++ b/hydrolib/core/io/bc/models.py
@@ -1,7 +1,7 @@
 import logging
 from enum import Enum
 from pathlib import Path
-from typing import Callable, Dict, List, Literal, NamedTuple, Optional, Set
+from typing import Callable, List, Literal, NamedTuple, Optional, Set
 
 from pydantic import Extra
 from pydantic.class_validators import root_validator, validator

--- a/hydrolib/core/io/ini/models.py
+++ b/hydrolib/core/io/ini/models.py
@@ -1,15 +1,6 @@
 import logging
 from abc import ABC
-from typing import (
-    Any,
-    Callable,
-    List,
-    Literal,
-    Optional,
-    Set,
-    Type,
-    Union,
-)
+from typing import Any, Callable, List, Literal, Optional, Set, Type, Union
 
 from pydantic import Extra, Field, root_validator
 from pydantic.class_validators import validator
@@ -22,12 +13,7 @@ from hydrolib.core.io.ini.util import (
     make_list_length_root_validator,
 )
 
-from .io_models import (
-    CommentBlock,
-    Document,
-    Property,
-    Section,
-)
+from .io_models import CommentBlock, Document, Property, Section
 from .parser import Parser
 from .serializer import SerializerConfig, write_ini
 from .util import make_list_validator

--- a/hydrolib/core/io/ini/models.py
+++ b/hydrolib/core/io/ini/models.py
@@ -1,17 +1,12 @@
 import logging
 from abc import ABC
-from functools import reduce
 from typing import (
     Any,
     Callable,
-    Dict,
-    Iterable,
     List,
     Literal,
     Optional,
-    Sequence,
     Set,
-    Tuple,
     Type,
     Union,
 )
@@ -21,7 +16,6 @@ from pydantic.class_validators import validator
 
 from hydrolib.core import __version__ as version
 from hydrolib.core.basemodel import BaseModel, FileModel
-from hydrolib.core.io.base import DummySerializer
 from hydrolib.core.io.ini.util import (
     get_from_subclass_defaults,
     get_split_string_on_delimiter_validator,
@@ -30,15 +24,12 @@ from hydrolib.core.io.ini.util import (
 
 from .io_models import (
     CommentBlock,
-    ContentElement,
-    Datablock,
-    DatablockRow,
     Document,
     Property,
     Section,
 )
 from .parser import Parser
-from .serializer import Serializer, SerializerConfig, write_ini
+from .serializer import SerializerConfig, write_ini
 from .util import make_list_validator
 
 logger = logging.getLogger(__name__)

--- a/hydrolib/core/io/ini/models.py
+++ b/hydrolib/core/io/ini/models.py
@@ -165,7 +165,7 @@ class INIBasedModel(BaseModel, ABC):
 class DataBlockINIBasedModel(INIBasedModel):
     """DataBlockINIBasedModel defines the base model for ini models with datablocks."""
 
-    datablock: List[List[float]] = []
+    datablock: List[List[Union[float, str]]] = []
 
     _make_lists = make_list_validator("datablock")
 

--- a/tests/io/test_bc.py
+++ b/tests/io/test_bc.py
@@ -6,6 +6,8 @@ from pydantic.error_wrappers import ValidationError
 
 from hydrolib.core.io.bc.models import (
     T3D,
+    Astronomic,
+    AstronomicCorrection,
     Constant,
     ForcingBase,
     ForcingModel,
@@ -211,11 +213,22 @@ class TestForcingModel:
         forcingmodel.forcing.append(t3d)
         forcingmodel.forcing.append(qhtable)
         forcingmodel.forcing.append(constant)
-
         forcingmodel.save()
 
         assert file.is_file() == True
         assert_files_equal(file, reference_file, skip_lines=[0, 3])
+
+    @pytest.mark.parametrize("cls", [Astronomic, AstronomicCorrection])
+    def test_astronomic_values_with_strings_in_datablock_are_parsed_correctly(
+        self, cls
+    ):
+        try:
+            is_correction = cls == AstronomicCorrection
+            _ = cls(**_create_astronomic_values(is_correction))
+        except ValidationError:
+            pytest.fail(
+                f"No validation error should be raised when creating an {cls.__name__}"
+            )
 
 
 def _create_time_series_values():


### PR DESCRIPTION
Adjust the datablock type from `List[List[float]]` to `List[List[Union[float, str]]]` such that string values are also properly parsed, but float values are preferred.

Fixes #137 