### PR TITLE
#211: Add configurable list delimiter symbol at Field and model level

### DIFF
--- a/hydrolib/core/basemodel.py
+++ b/hydrolib/core/basemodel.py
@@ -16,7 +16,7 @@ from weakref import WeakValueDictionary
 
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic.error_wrappers import ErrorWrapper, ValidationError
-from pydantic.fields import ModelField, PrivateAttr
+from pydantic.fields import PrivateAttr
 
 from hydrolib.core.io.base import DummmyParser, DummySerializer
 from hydrolib.core.utils import to_key
@@ -106,38 +106,6 @@ class BaseModel(PydanticBaseModel):
             str: The identifier or None.
         """
         return None
-
-    @classmethod
-    def get_list_delimiter(cls) -> str:
-        """List delimiter string that will be used for serializing
-        list field values for any pydantic ModelField in this BaseModel,
-        **if** that field has no custom list delimiter.
-
-        This function should be overridden by any subclass for a particular
-        filetype that needs a specific/different list separator.
-        """
-        # Dummy default for this BaseModel class
-        return ","
-
-    @classmethod
-    def get_list_field_delimiter(cls, field_key: str) -> str:
-        """List delimiter string that will be used for serializing
-        the given field's value.
-        The returned delimiter is either the field's custom list delimiter
-        if that was specified using Field(.., delimiter=".."), or the
-        default list delimiter for the model class that this field belongs
-        to.
-
-        Args:
-            field_key (str): the original field key (not its alias).
-        """
-        delimiter = None
-        if (field := cls.__fields__.get(field_key)) and isinstance(field, ModelField):
-            delimiter = field.field_info.extra.get("delimiter")
-        if not delimiter:
-            delimiter = cls.get_list_delimiter()
-
-        return delimiter
 
 
 TAcc = TypeVar("TAcc")

--- a/hydrolib/core/basemodel.py
+++ b/hydrolib/core/basemodel.py
@@ -16,7 +16,7 @@ from weakref import WeakValueDictionary
 
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic.error_wrappers import ErrorWrapper, ValidationError
-from pydantic.fields import PrivateAttr
+from pydantic.fields import ModelField, PrivateAttr
 
 from hydrolib.core.io.base import DummmyParser, DummySerializer
 from hydrolib.core.utils import to_key
@@ -106,6 +106,38 @@ class BaseModel(PydanticBaseModel):
             str: The identifier or None.
         """
         return None
+
+    @classmethod
+    def get_list_delimiter(cls) -> str:
+        """List delimiter string that will be used for serializing
+        list field values for any pydantic ModelField in this BaseModel,
+        **if** that field has no custom list delimiter.
+
+        This function should be overridden by any subclass for a particular
+        filetype that needs a specific/different list separator.
+        """
+        # Dummy default for this BaseModel class
+        return ","
+
+    @classmethod
+    def get_list_field_delimiter(cls, field_key: str) -> str:
+        """List delimiter string that will be used for serializing
+        the given field's value.
+        The returned delimiter is either the field's custom list delimiter
+        if that was specified using Field(.., delimiter=".."), or the
+        default list delimiter for the model class that this field belongs
+        to.
+
+        Args:
+            field_key (str): the original field key (not its alias).
+        """
+        delimiter = None
+        if (field := cls.__fields__.get(field_key)) and isinstance(field, ModelField):
+            delimiter = field.field_info.extra.get("delimiter")
+        if not delimiter:
+            delimiter = cls.get_list_delimiter()
+
+        return delimiter
 
 
 TAcc = TypeVar("TAcc")

--- a/hydrolib/core/io/crosssection/models.py
+++ b/hydrolib/core/io/crosssection/models.py
@@ -344,8 +344,10 @@ class ZWRiverCrsDef(CrossSectionDefinition):
     mainwidth: Optional[float] = Field(alias="mainWidth")
     fp1width: Optional[float] = Field(alias="fp1Width")
     fp2width: Optional[float] = Field(alias="fp2Width")
-    frictionids: Optional[List[str]] = Field(alias="frictionIds")
-    frictiontypes: Optional[List[FrictionType]] = Field(alias="frictionTypes")
+    frictionids: Optional[List[str]] = Field(alias="frictionIds", delimiter=";")
+    frictiontypes: Optional[List[FrictionType]] = Field(
+        alias="frictionTypes", delimiter=";"
+    )
     frictionvalues: Optional[List[float]] = Field(alias="frictionValues")
 
     _split_to_list = get_split_string_on_delimiter_validator(
@@ -513,8 +515,10 @@ class YZCrsDef(CrossSectionDefinition):
     conveyance: Optional[str] = Field("segmented")
     sectioncount: Optional[int] = Field(1, alias="sectionCount")
     frictionpositions: Optional[List[float]] = Field(alias="frictionPositions")
-    frictionids: Optional[List[str]] = Field(alias="frictionIds")
-    frictiontypes: Optional[List[FrictionType]] = Field(alias="frictionTypes")
+    frictionids: Optional[List[str]] = Field(alias="frictionIds", delimiter=";")
+    frictiontypes: Optional[List[FrictionType]] = Field(
+        alias="frictionTypes", delimiter=";"
+    )
     frictionvalues: Optional[List[float]] = Field(alias="frictionValues")
 
     _split_to_list = get_split_string_on_delimiter_validator(

--- a/hydrolib/core/io/mdu/models.py
+++ b/hydrolib/core/io/mdu/models.py
@@ -444,7 +444,9 @@ class Geometry(INIBasedModel):
     drypointsfile: Optional[List[Union[XYZModel, PolyFile]]] = Field(
         None, alias="dryPointsFile"
     )  # TODO Fix, this will always try XYZ first, alias="]")
-    structurefile: Optional[List[StructureModel]] = Field(None, alias="structureFile")
+    structurefile: Optional[List[StructureModel]] = Field(
+        None, alias="structureFile", delimiter=";"
+    )
     inifieldfile: Optional[IniFieldModel] = Field(None, alias="iniFieldFile")
     waterlevinifile: Optional[Path] = Field(None, alias="waterLevIniFile")
     landboundaryfile: Optional[List[Path]] = Field(None, alias="landBoundaryFile")
@@ -453,7 +455,9 @@ class Geometry(INIBasedModel):
     pillarfile: Optional[List[PolyFile]] = Field(None, alias="pillarFile")
     usecaching: bool = Field(False, alias="useCaching")
     vertplizfile: Optional[PolyFile] = Field(None, alias="vertPlizFile")
-    frictfile: Optional[List[FrictionModel]] = Field(None, alias="frictFile")
+    frictfile: Optional[List[FrictionModel]] = Field(
+        None, alias="frictFile", delimiter=";"
+    )
     crossdeffile: Optional[CrossDefModel] = Field(None, alias="crossDefFile")
     crosslocfile: Optional[CrossLocModel] = Field(None, alias="crossLocFile")
     storagenodefile: Optional[StorageNodeModel] = Field(None, alias="storageNodeFile")
@@ -492,12 +496,16 @@ class Geometry(INIBasedModel):
     _split_to_list = get_split_string_on_delimiter_validator(
         "frictfile",
         "structurefile",
+        delimiter=";",
+    )
+
+    _split_to_list2 = get_split_string_on_delimiter_validator(
         "drypointsfile",
         "landboundaryfile",
         "thindamfile",
         "fixedweirfile",
         "pillarfile",
-        delimiter=";",
+        delimiter=" ",
     )
 
     def is_intermediate_link(self) -> bool:

--- a/hydrolib/core/io/structure/models.py
+++ b/hydrolib/core/io/structure/models.py
@@ -498,7 +498,7 @@ class Compound(Structure):
 
     type: Literal["compound"] = Field("compound", alias="type")
     numstructures: int = Field(alias="numStructures")
-    structureids: List[str] = Field(alias="structureIds")
+    structureids: List[str] = Field(alias="structureIds", delimiter=";")
 
     _split_to_list = get_split_string_on_delimiter_validator(
         "structureids", delimiter=";"

--- a/tests/data/reference/bc/test.bc
+++ b/tests/data/reference/bc/test.bc
@@ -48,7 +48,7 @@
     function              = t3d
     offset                = 1.23
     factor                = 2.34
-    verticalPositions     = 3.45;4.56;5.67
+    verticalPositions     = 3.45 4.56 5.67
     verticalInterpolation = log
     verticalPositionType  = percBed
     quantity              = time

--- a/tests/data/reference/fm/serialize_roughness.ini
+++ b/tests/data/reference/fm/serialize_roughness.ini
@@ -18,8 +18,8 @@
     numLevels      =           # Number of levels in table. Only if functionType is not constant.
     levels         =           # Space separated list of discharge [m3/s] or water level [m AD] values. Only if functionType is absDischarge or waterLevel.
     numLocations   = 2         # at two locations
-    chainage       = 0.0;100.0
-    frictionValues = 0.2;0.3
+    chainage       = 0.0 100.0
+    frictionValues = 0.2 0.3
 
 [Branch]
     branchId       = Channel4


### PR DESCRIPTION
Fixes #211.

* Any Pydantic BaseModel subclass can now optionally add a `Field(.., delimiter="..")` argument if a particular ModelField has a non-standard delimiter
* Added BaseModel helper function `get_list_field_delimiter`, which gets either the custom list delimiter for that field, or the default list delimiter of the model class (or the first parent class above it that defines it)
* IniBasedModel defines the main default delimiter=" "
* structure, crosssection and mdu submodels now have a custom list delimiter for a few of their fields.
* Some reference test files had to be updated, because they were using wrong list separators.