### PR TITLE
ignore location fields for compound type structures

### DIFF
--- a/hydrolib/core/io/structure/models.py
+++ b/hydrolib/core/io/structure/models.py
@@ -68,6 +68,10 @@ class Structure(INIBasedModel):
     xcoordinates: Optional[List[float]] = Field(None, alias="xCoordinates")
     ycoordinates: Optional[List[float]] = Field(None, alias="yCoordinates")
 
+    _loc_coord_fields = {"numcoordinates", "xcoordinates", "ycoordinates"}
+    _loc_branch_fields = {"branchid", "chainage"}
+    _loc_all_fields = _loc_coord_fields | _loc_branch_fields
+
     _split_to_list = get_split_string_on_delimiter_validator(
         "xcoordinates", "ycoordinates"
     )
@@ -97,8 +101,18 @@ class Structure(INIBasedModel):
         filtered_values = {k: v for k, v in values.items() if v is not None}
         structype = filtered_values.get("type", "").lower()
 
+        if structype == "compound" or issubclass(cls, Compound):
+            loc_in_model = any(
+                k.lower() in cls._loc_all_fields for k in filtered_values.keys()
+            )
+            # TODO: issue 214: enable the assert below once the D-HYDRO Suite 1D2D
+            # has fixed issue FM1D2D-1935 for compound structures.
+            # assert (
+            #     not loc_in_model
+            # ), f"No `num/x/yCoordinates` nor `branchId+chainage` are allowed for a {structype} structure."
+
         # TODO This seems to be a bit of a hack.
-        if not (structype == "compound" or issubclass(cls, (Compound, Dambreak))):
+        elif not (structype == "compound" or issubclass(cls, (Compound, Dambreak))):
             # Compound structure does not require a location specification.
             only_coordinates_structures = dict(
                 longculvert="LongCulvert", dambreak="Dambreak"
@@ -214,11 +228,13 @@ class Structure(INIBasedModel):
         return super().validate(v)
 
     def _exclude_fields(self) -> Set:
-        # exclude the unset props like coordinates or branches
-        if self.branchid is not None:
-            exclude_set = {"numcoordinates", "xcoordinates", "ycoordinates"}
+        # exclude the non-applicable, or unset props like coordinates or branches
+        if self.type is "compound":
+            exclude_set = self._loc_all_fields
+        elif self.branchid is not None:
+            exclude_set = self._loc_coord_fields
         else:
-            exclude_set = {"branchid", "chainage"}
+            exclude_set = self._loc_branch_fields
         exclude_set = super()._exclude_fields().union(exclude_set)
         return exclude_set
 

--- a/hydrolib/core/io/structure/models.py
+++ b/hydrolib/core/io/structure/models.py
@@ -101,18 +101,7 @@ class Structure(INIBasedModel):
         filtered_values = {k: v for k, v in values.items() if v is not None}
         structype = filtered_values.get("type", "").lower()
 
-        if structype == "compound" or issubclass(cls, Compound):
-            loc_in_model = any(
-                k.lower() in cls._loc_all_fields for k in filtered_values.keys()
-            )
-            # TODO: issue 214: enable the assert below once the D-HYDRO Suite 1D2D
-            # has fixed issue FM1D2D-1935 for compound structures.
-            # assert (
-            #     not loc_in_model
-            # ), f"No `num/x/yCoordinates` nor `branchId+chainage` are allowed for a {structype} structure."
-
-        # TODO This seems to be a bit of a hack.
-        elif not (structype == "compound" or issubclass(cls, (Compound, Dambreak))):
+        if not (structype == "compound" or issubclass(cls, (Compound, Dambreak))):
             # Compound structure does not require a location specification.
             only_coordinates_structures = dict(
                 longculvert="LongCulvert", dambreak="Dambreak"

--- a/tests/io/test_structure.py
+++ b/tests/io/test_structure.py
@@ -205,7 +205,12 @@ def test_create_structure_without_type():
     ],
 )
 def test_parses_type_case_insensitive(input, expected):
-    structure = Structure(type=input, branchid="branchid", chainage="1")
+    if input.lower() != "compound":
+        locfields = {"branchid": "branchid", "chainage": 1}
+    else:
+        locfields = {}
+
+    structure = Structure(type=input, **locfields)
 
     assert structure.type == expected
 
@@ -615,7 +620,7 @@ class TestStructure:
                     return
             assert str(exc_err.value) == error_mssg
 
-        def test_check_location_given_compound_structure_raises_nothing(self):
+        def test_check_nolocation_given_compound_structure_raises_nothing(self):
             input_dict = dict(
                 notAValue="Not a relevant value",
                 numcoordinates=None,
@@ -626,6 +631,28 @@ class TestStructure:
             )
             return_value = Compound.check_location(input_dict)
             assert return_value == input_dict
+
+        def test_check_location_given_compound_structure_raises_error(self):
+            input_dict = dict(
+                notAValue="Not a relevant value",
+                numcoordinates=None,
+                xcoordinates=None,
+                ycoordinates=None,
+                branchid="branch01",
+                chainage=123.4,
+            )
+            return_value = Compound.check_location(input_dict)
+            assert return_value == input_dict
+
+            # TODO: issue 214: replace the above test code by the test
+            # code below once the D-HYDRO Suite 1D2D has fixed issue
+            # FM1D2D-1935 for compound structures.
+            # with pytest.raises(AssertionError) as exc_err:
+            #     _ = Compound.check_location(input_dict)
+            #     assert (
+            #         str(exc_err.value)
+            #         == "No `num/x/yCoordinates` nor `branchId+chainage` are allowed for a compound structure."
+            #     )
 
         @pytest.mark.parametrize(
             "dict_values",

--- a/tests/io/test_structure.py
+++ b/tests/io/test_structure.py
@@ -170,23 +170,27 @@ def test_read_structures_missing_structure_field_raises_correct_error():
     assert expected_message in str(error.value)
 
 
-def test_create_structure_without_id():
+@pytest.fixture
+def locfields_structure():
+    """example location fields for creating a regular Structure"""
+    return {"branchid": "branch", "chainage": 10}
+
+
+def test_create_structure_without_id(locfields_structure):
     field = "id"
     with pytest.raises(ValidationError) as error:
-        _ = Structure(branchid="branch", chainage=10)  # Intentionally no id+type
+        _ = Structure(**locfields_structure)  # Intentionally no id+type
 
     expected_message = f"{field}"
     assert expected_message in str(error.value)
     assert error.value.errors()[0]["type"] == "value_error.missing"
 
 
-def test_create_structure_without_type():
+def test_create_structure_without_type(locfields_structure):
     identifier = "structA"
     field = "type"
     with pytest.raises(ValidationError) as error:
-        _ = Structure(
-            id=identifier, branchid="branch", chainage=10
-        )  # Intentionally no type
+        _ = Structure(id=identifier, **locfields_structure)  # Intentionally no type
 
     expected_message = f"{identifier} -> {field}"
     assert expected_message in str(error.value)
@@ -200,17 +204,23 @@ def test_create_structure_without_type():
         ("UniversalWeir", "universalWeir"),
         ("Culvert", "culvert"),
         ("Pump", "pump"),
-        ("Compound", "compound"),
         ("Orifice", "orifice"),
     ],
 )
-def test_parses_type_case_insensitive(input, expected):
-    if input.lower() != "compound":
-        locfields = {"branchid": "branchid", "chainage": 1}
-    else:
-        locfields = {}
+def test_parses_structure_type_case_insensitive(locfields_structure, input, expected):
+    structure = Structure(type=input, **locfields_structure)
 
-    structure = Structure(type=input, **locfields)
+    assert structure.type == expected
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        ("Compound", "compound"),
+    ],
+)
+def test_parses_compound_type_case_insensitive(input, expected):
+    structure = Structure(type=input)
 
     assert structure.type == expected
 


### PR DESCRIPTION
Fixes #214.
* serialization now hides all location fields, thanks to improved _exclude_fields
* I've prepared improved validation upon parsing, but left the code commented out, because the D-HYDRO Suite 1D2D currently still writes branchId+chainage for compounds (but this will have to change)
* also added extra unit test for the compound reading.