### PR TITLE
#204: Avoid Pydantic 1.9.x as long as List[Union[]] types are unsupported

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 python = "^3.8"
 netCDF4 = "1.5.7"
 numpy = "^1.21"
-pydantic = {extras = ["dotenv"], version = "^1.8"}
+pydantic = {extras = ["dotenv"], version = "~1.8"}
 lxml = "^4.6"
 meshkernel = "^1.0.0"
 mkdocs-macros-plugin = "^0.6.3"


### PR DESCRIPTION
Fixes #204.