### PR TITLE
chore(devcontainer): fix docker devcontainer behaviour

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,4 +21,6 @@
 	"mounts": [
 		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
 	],
+	// This ensures the HYDROLIB environment is properly installed. 
+	"postCreateCommand": "poetry install --no-root --no-interaction --no-ansi"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 	// Additional extensions can be added here according to personal taste.
 	"extensions": [
 		"ms-python.python",
-		"littlefoxteam.vscode-python-test-adapter",
+		"ms-vscode.test-adapter-converter",
 		"oderwat.indent-rainbow",
 		"njpwerner.autodocstring",
 		"njqdev.vscode-python-typehint"

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ WORKDIR $PYSETUP_PATH
 COPY poetry.lock pyproject.toml ./
 
 # install runtime deps - uses $POETRY_VIRTUALENVS_IN_PROJECT internally
-RUN poetry install --no-dev --no-root
+RUN poetry install --no-dev --no-root --no-interaction --no-ansi
 
 
 # `development` image is used during development / testing
@@ -69,7 +69,7 @@ COPY --from=builder-base $POETRY_HOME $POETRY_HOME
 COPY --from=builder-base $PYSETUP_PATH $PYSETUP_PATH
 
 # quicker install as runtime deps are already installed
-RUN poetry install --no-root
+RUN poetry install --no-interaction --no-ansi --no-root
 
 # will become mountpoint of our code
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ENV PYTHONUNBUFFERED=1 \
     POETRY_VIRTUALENVS_IN_PROJECT=true \
     # do not ask any interactive question
     POETRY_NO_INTERACTION=1 \
+    POETRY_NO_ANSI=1\
     \
     # paths
     # this is where our requirements + virtual environment will live
@@ -34,8 +35,6 @@ ENV PYTHONUNBUFFERED=1 \
 # prepend poetry and venv to path
 ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH"
 
-# `builder-base` stage is used to build deps + create our virtual environment
-FROM python-base as builder-base
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     # deps for installing poetry
@@ -46,32 +45,19 @@ RUN apt-get update \
 # install poetry - respects $POETRY_VERSION & $POETRY_HOME
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python
 
-# copy project requirement files here to ensure they will be cached.
-WORKDIR $PYSETUP_PATH
-COPY poetry.lock pyproject.toml ./
-
-# install runtime deps - uses $POETRY_VIRTUALENVS_IN_PROJECT internally
-RUN poetry install --no-dev --no-root --no-interaction --no-ansi
-
-
 # `development` image is used during development / testing
 FROM python-base as development
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
-WORKDIR $PYSETUP_PATH
 
 # Install git, to ensure the git tools work within vs-code
 RUN apt-get update \
     && apt-get install git-all --no-install-recommends -y
 
+COPY --from=python-base $POETRY_HOME $POETRY_HOME
 
-# copy in our built poetry + venv
-COPY --from=builder-base $POETRY_HOME $POETRY_HOME
-COPY --from=builder-base $PYSETUP_PATH $PYSETUP_PATH
-
-# quicker install as runtime deps are already installed
-RUN poetry install --no-interaction --no-ansi --no-root
-
-# will become mountpoint of our code
 WORKDIR /app
+
+# The actual 'poetry install' is called after the code is mounted. 
+# See '.devcontainer/devcontainer.json'
 
 EXPOSE 8000

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -40,15 +40,24 @@ or we can select the  "Open a Remote Window" button, the green button in the bot
 code window, after which we can select "Reopen in container". Both will then spin up a new container in which we can work.
 Note that if it is the first time starting our repository, or if we have made changes to the Docker Images we might need to build the container, which could take a few moments.
 
-Once opened in a separate container, we can start a terminal to verify everything is working correctly. 
-When we start a new terminal, we should see the terminal of our container, e.g. something a long the lines of
+Once opened in a separate container, we can start a terminal to verify everything is 
+working correctly. First, we need to ensure the correct python interpreter is used. 
+We want to use the virtual environment created by poetry, which default resides in 
+`./.venv/`. Visual Studio Code might prompt you to select an interpreter. If it does
+press the 'Select Python Interpreter', and select the virtual environment residing in
+`./.venv/`. If it does not explicitly prompt you (or if you want to change it later on),
+press `ctrl + shift + p`, and select 'Python: Select Interpreter'. If it currently is 
+not set to the virtual environment, change it to the correct interpreter.
 
-```bash
-(.venv) root@7573572275f1:/workspaces/HYDROLIB-core# 
-```
+It should now be possible to run the HYDROLIB-Core tests within our container by opening 
+the 'Testing' tab. If the 'Testing' is not already configured in the 
+`./.vscode/settings.json`, we will need to configure the Python tests:
 
-It should now be possible to run the HYDROLIB-Core tests within our container. You might get prompted to configure either
-the python interpreter, or the python test framework. Once this is done all tests should pass as they would normally.
+1. click the 'Configure Python Tests' button in the 'Testing' tab
+2. Select 'pytest' in the pop-up window
+3. Select 'tests', this will ensure tests are located in our 'tests' directory
+
+Once this is done all tests should pass as they would normally.
 
 ##  Dockerfile configures python, poetry and other dependencies
 


### PR DESCRIPTION
- Simplify the Dockerfile to only install poetry and other dependencies in the devcontainer
- Extend the devcontainer to run the `poetry install` command after creation of the environment
- Update the devcontainer documentation

Fixes #230 