### PR TITLE
#104: Skip serialization of empty INI properties when configured

### DIFF
--- a/hydrolib/core/basemodel.py
+++ b/hydrolib/core/basemodel.py
@@ -829,6 +829,7 @@ class ParsableFileModel(FileModel):
         self._serialize(self.dict())
 
     def _serialize(self, data: dict) -> None:
+        """Serializes the data to file. Should not be called directly, only through `_save`."""
         path = self._resolved_filepath
         if path is None:
             # TODO: Do we need to add a warning / exception here

--- a/hydrolib/core/io/ini/parser.py
+++ b/hydrolib/core/io/ini/parser.py
@@ -19,7 +19,7 @@ class ParserConfig(BaseModel):
     Attributes:
         allow_only_keywords (bool):
             Whether to allow properties with only keys (no '=' or value).
-            Defaults to True.
+            Defaults to False.
         parse_datablocks (bool):
             Whether to allow parsing of datablocks at the bottom of sections.
             Defaults to False.

--- a/hydrolib/core/io/ini/serializer.py
+++ b/hydrolib/core/io/ini/serializer.py
@@ -44,7 +44,7 @@ class SerializerConfig(BaseModel):
     datablock_indent: int = 8
     datablock_spacing: int = 4
     comment_delimiter: str = "#"
-    skip_empty_properties: bool = False
+    skip_empty_properties: bool = True
 
     @property
     def total_property_indent(self) -> int:

--- a/hydrolib/core/io/ini/serializer.py
+++ b/hydrolib/core/io/ini/serializer.py
@@ -34,6 +34,8 @@ class SerializerConfig(BaseModel):
             additional offset to ensure . is lined out. Defaults to 4.
         comment_delimiter (str):
             The character used to delimit comments. Defaults to '#'.
+        skip_empty_properties (bool):
+            Whether or not to skip properties with a value that is empty or None. Defaults to False. 
     """
 
     section_indent: int = 0
@@ -41,6 +43,7 @@ class SerializerConfig(BaseModel):
     datablock_indent: int = 8
     datablock_spacing: int = 4
     comment_delimiter: str = "#"
+    skip_empty_properties: bool = False
 
     @property
     def total_property_indent(self) -> int:

--- a/hydrolib/core/io/ini/serializer.py
+++ b/hydrolib/core/io/ini/serializer.py
@@ -36,7 +36,7 @@ class SerializerConfig(BaseModel):
         comment_delimiter (str):
             The character used to delimit comments. Defaults to '#'.
         skip_empty_properties (bool):
-            Whether or not to skip properties with a value that is empty or None. Defaults to False. 
+            Whether or not to skip properties with a value that is empty or None. Defaults to False.
     """
 
     section_indent: int = 0
@@ -198,7 +198,7 @@ class SectionSerializer:
     def _serialize_property(self, property: Property) -> Lines:
         if self.config.skip_empty_properties and str_is_empty_or_none(property.value):
             return
-        
+
         indent = " " * (self._config.total_property_indent)
         key_ws = _get_offset_whitespace(property.key, self.max_length.key)
         key = f"{property.key}{key_ws} = "

--- a/hydrolib/core/io/ini/serializer.py
+++ b/hydrolib/core/io/ini/serializer.py
@@ -36,7 +36,7 @@ class SerializerConfig(BaseModel):
         comment_delimiter (str):
             The character used to delimit comments. Defaults to '#'.
         skip_empty_properties (bool):
-            Whether or not to skip properties with a value that is empty or None. Defaults to False.
+            Whether or not to skip properties with a value that is empty or None. Defaults to True.
     """
 
     section_indent: int = 0

--- a/hydrolib/core/io/ini/serializer.py
+++ b/hydrolib/core/io/ini/serializer.py
@@ -12,6 +12,7 @@ from hydrolib.core.io.ini.io_models import (
     Property,
     Section,
 )
+from hydrolib.core.utils import str_is_empty_or_none
 
 
 class SerializerConfig(BaseModel):
@@ -195,6 +196,9 @@ class SectionSerializer:
             return _serialize_comment_block(elem, delimiter, indent)
 
     def _serialize_property(self, property: Property) -> Lines:
+        if self.config.skip_empty_properties and str_is_empty_or_none(property.value):
+            return
+        
         indent = " " * (self._config.total_property_indent)
         key_ws = _get_offset_whitespace(property.key, self.max_length.key)
         key = f"{property.key}{key_ws} = "

--- a/hydrolib/core/io/mdu/models.py
+++ b/hydrolib/core/io/mdu/models.py
@@ -14,6 +14,7 @@ from hydrolib.core.io.crosssection.models import CrossDefModel, CrossLocModel
 from hydrolib.core.io.ext.models import ExtModel
 from hydrolib.core.io.friction.models import FrictionModel
 from hydrolib.core.io.ini.models import INIBasedModel, INIGeneral, INIModel
+from hydrolib.core.io.ini.serializer import SerializerConfig, write_ini
 from hydrolib.core.io.ini.util import get_split_string_on_delimiter_validator
 from hydrolib.core.io.inifield.models import IniFieldModel
 from hydrolib.core.io.net.models import NetworkModel
@@ -820,3 +821,7 @@ class FMModel(INIModel):
             return ResolveRelativeMode.ToAnchor
         else:
             return ResolveRelativeMode.ToParent
+
+    def _serialize(self, _: dict) -> None:
+        config = SerializerConfig(skip_empty_properties=False)
+        write_ini(self._resolved_filepath, self._to_document(), config=config)

--- a/tests/data/reference/fm/serialize_initialFields.ini
+++ b/tests/data/reference/fm/serialize_initialFields.ini
@@ -1,4 +1,4 @@
-# written by HYDROLIB-core 0.1.5
+# written by HYDROLIB-core 0.3.0
 
 [General]
     fileVersion = 2.00
@@ -16,13 +16,11 @@
     averagingPercentile = 0                  # Percentile value for which data values to include in averaging. 0.0 means off.
     extrapolationMethod = 0                  # Option for (spatial) extrapolation.
     locationType        = 2d
-    value               =                    # Only for dataFileType=polygon. The constant value to be set inside for all model points inside the polygon.
 
 [Initial]
     quantity            = bedlevel
     dataFile            = inibedlevel.ini
     dataFileType        = 1dField
-    interpolationMethod =                 # Type of (spatial) interpolation.
     operand             = O               # How this data is combined with previous data for the same quantity (if any).
     averagingType       = mean            # Type of averaging, if interpolationMethod=averaging .
     averagingRelSize    = 1.01            # Relative search cell size for averaging.
@@ -30,7 +28,6 @@
     averagingPercentile = 0               # Percentile value for which data values to include in averaging. 0.0 means off.
     extrapolationMethod = 0               # Option for (spatial) extrapolation.
     locationType        = all             # Target location of interpolation.
-    value               =                 # Only for dataFileType=polygon. The constant value to be set inside for all model points inside the polygon.
 
 [Parameter]
     quantity            = frictioncoefficient
@@ -44,7 +41,6 @@
     averagingPercentile = 0                   # Percentile value for which data values to include in averaging. 0.0 means off.
     extrapolationMethod = 0                   # Option for (spatial) extrapolation.
     locationType        = all                 # Target location of interpolation.
-    value               =                     # Only for dataFileType=polygon. The constant value to be set inside for all model points inside the polygon.
 
 [Parameter]
     quantity            = frictioncoefficient

--- a/tests/data/reference/fm/serialize_roughness.ini
+++ b/tests/data/reference/fm/serialize_roughness.ini
@@ -1,9 +1,8 @@
-# written by HYDROLIB-core 0.1.6*
+# written by HYDROLIB-core 0.3.0
 
 [General]
     fileVersion        = 3.01
     fileType           = roughness
-    frictionValuesFile =           # Name of <*.bc> file containing the timeseries with friction values. Only needed for functionType = timeSeries.
 
 [Global]
     frictionId    = Main
@@ -14,9 +13,6 @@
     branchId       = Channel1
     frictionType   = Manning
     functionType   = constant
-    timeSeriesId   =           # Refers to a data block in the <*.bc> frictionValuesFile. Only if functionType = timeSeries.
-    numLevels      =           # Number of levels in table. Only if functionType is not constant.
-    levels         =           # Space separated list of discharge [m3/s] or water level [m AD] values. Only if functionType is absDischarge or waterLevel.
     numLocations   = 2         # at two locations
     chainage       = 0.0 100.0
     frictionValues = 0.2 0.3
@@ -25,10 +21,6 @@
     branchId       = Channel4
     frictionType   = Chezy
     functionType   = constant
-    timeSeriesId   =          # Refers to a data block in the <*.bc> frictionValuesFile. Only if functionType = timeSeries.
-    numLevels      =          # Number of levels in table. Only if functionType is not constant.
-    levels         =          # Space separated list of discharge [m3/s] or water level [m AD] values. Only if functionType is absDischarge or waterLevel.
     numLocations   = 0        # Number of locations on branch. The default 0 implies branch uniform values.
-    chainage       =          # Space separated list of locations on the branch [m]. Locations sorted by increasing chainage. The keyword must be specified if numLocations>0.
     frictionValues = 40.0
 

--- a/tests/io/test_ini.py
+++ b/tests/io/test_ini.py
@@ -1607,7 +1607,7 @@ class TestSerializer:
                     property_indent=4,
                     datablock_indent=6,
                     datablock_spacing=4,
-                    skip_empty_properties=False
+                    skip_empty_properties=False,
                 ),
                 [
                     "[header]",
@@ -1631,12 +1631,9 @@ class TestSerializer:
                     property_indent=4,
                     datablock_indent=6,
                     datablock_spacing=4,
-                    skip_empty_properties=True
+                    skip_empty_properties=True,
                 ),
-                [
-                    "[header]",
-                    "    key1 = value # comment1"
-                ],
+                ["[header]", "    key1 = value # comment1"],
             ),
         ],
     )

--- a/tests/io/test_ini.py
+++ b/tests/io/test_ini.py
@@ -1627,6 +1627,7 @@ class TestSerializer:
                         Property(key="key1", value="value", comment="comment1"),
                         Property(key="key2", value="", comment="comment2"),
                         Property(key="key3", value=None, comment="comment3"),
+                        Property(key="key4", value="   ", comment="comment4"),
                     ],
                     datablock=[],
                 ),

--- a/tests/io/test_ini.py
+++ b/tests/io/test_ini.py
@@ -803,6 +803,15 @@ class TestSerializerConfig:
         config = SerializerConfig(section_indent=3, datablock_indent=10)
         assert config.total_datablock_indent == 13
 
+    def test_default_serializer_config(self):
+        config = SerializerConfig()
+        assert config.section_indent == 0
+        assert config.property_indent == 4
+        assert config.datablock_indent == 8
+        assert config.datablock_spacing == 4
+        assert config.comment_delimiter == "#"
+        assert config.skip_empty_properties == False
+
 
 class TestLengths:
     @pytest.mark.parametrize(

--- a/tests/io/test_ini.py
+++ b/tests/io/test_ini.py
@@ -1592,6 +1592,52 @@ class TestSerializer:
                     "      1.0     16.0    81.0    256.0",
                 ],
             ),
+            (
+                Section(
+                    header="header",
+                    content=[
+                        Property(key="key1", value="value", comment="comment1"),
+                        Property(key="key2", value="", comment="comment2"),
+                        Property(key="key3", value=None, comment="comment3"),
+                    ],
+                    datablock=[],
+                ),
+                SerializerConfig(
+                    section_indent=0,
+                    property_indent=4,
+                    datablock_indent=6,
+                    datablock_spacing=4,
+                    skip_empty_properties=False
+                ),
+                [
+                    "[header]",
+                    "    key1 = value # comment1",
+                    "    key2 =       # comment2",
+                    "    key3 =       # comment3",
+                ],
+            ),
+            (
+                Section(
+                    header="header",
+                    content=[
+                        Property(key="key1", value="value", comment="comment1"),
+                        Property(key="key2", value="", comment="comment2"),
+                        Property(key="key3", value=None, comment="comment3"),
+                    ],
+                    datablock=[],
+                ),
+                SerializerConfig(
+                    section_indent=0,
+                    property_indent=4,
+                    datablock_indent=6,
+                    datablock_spacing=4,
+                    skip_empty_properties=True
+                ),
+                [
+                    "[header]",
+                    "    key1 = value # comment1"
+                ],
+            ),
         ],
     )
     def test_serialize_section(

--- a/tests/io/test_ini.py
+++ b/tests/io/test_ini.py
@@ -1269,13 +1269,17 @@ class TestSerializer:
             (
                 Property(key="key", value=None, comment=None),
                 MaxLengths(key=3, value=0),
-                SerializerConfig(section_indent=0, property_indent=0, skip_empty_properties=False),
+                SerializerConfig(
+                    section_indent=0, property_indent=0, skip_empty_properties=False
+                ),
                 "key =",
             ),
             (
                 Property(key="key", value=None, comment="comment"),
                 MaxLengths(key=3, value=5),
-                SerializerConfig(section_indent=0, property_indent=0, skip_empty_properties=False),
+                SerializerConfig(
+                    section_indent=0, property_indent=0, skip_empty_properties=False
+                ),
                 "key =       # comment",
             ),
             (

--- a/tests/io/test_ini.py
+++ b/tests/io/test_ini.py
@@ -810,7 +810,7 @@ class TestSerializerConfig:
         assert config.datablock_indent == 8
         assert config.datablock_spacing == 4
         assert config.comment_delimiter == "#"
-        assert config.skip_empty_properties == False
+        assert config.skip_empty_properties == True
 
 
 class TestLengths:
@@ -1269,13 +1269,13 @@ class TestSerializer:
             (
                 Property(key="key", value=None, comment=None),
                 MaxLengths(key=3, value=0),
-                SerializerConfig(section_indent=0, property_indent=0),
+                SerializerConfig(section_indent=0, property_indent=0, skip_empty_properties=False),
                 "key =",
             ),
             (
                 Property(key="key", value=None, comment="comment"),
                 MaxLengths(key=3, value=5),
-                SerializerConfig(section_indent=0, property_indent=0),
+                SerializerConfig(section_indent=0, property_indent=0, skip_empty_properties=False),
                 "key =       # comment",
             ),
             (
@@ -1678,7 +1678,7 @@ class TestSerializer:
 
         document = parser.finalize()
 
-        serializer = Serializer(config=SerializerConfig())
+        serializer = Serializer(config=SerializerConfig(skip_empty_properties=False))
         result = "\n".join(serializer.serialize(document))
 
         assert result == input_str
@@ -1772,7 +1772,7 @@ def test_serialize_deserialize_should_give_the_same_result():
     )
 
     path = test_output_dir / "tmp" / "test.pliz"
-    write_ini(path, document)
+    write_ini(path, document, config=SerializerConfig(skip_empty_properties=False))
 
     parser = Parser(config=ParserConfig(parse_datablocks=True))
     with path.open("r") as f:


### PR DESCRIPTION
Fixes #104 