### PR TITLE
321: Add option warn_dropped_extra to BaseModel Config

### DIFF
--- a/tests/io/test_bc.py
+++ b/tests/io/test_bc.py
@@ -5,6 +5,7 @@ from typing import List
 import pytest
 from pydantic.error_wrappers import ValidationError
 
+from hydrolib.core.basemodel import BaseModel, warnings_enabled
 from hydrolib.core.io.bc.models import (
     T3D,
     Astronomic,
@@ -21,7 +22,6 @@ from hydrolib.core.io.bc.models import (
     VerticalInterpolation,
     VerticalPositionType,
 )
-from hydrolib.core.io.ini.models import BaseModel
 from hydrolib.core.io.ini.parser import Parser, ParserConfig
 
 from ..utils import (
@@ -72,6 +72,23 @@ class TestTimeSeries:
         assert forcing.datablock[0] == [0, 1.23]
         assert forcing.datablock[1] == [60, 2.34]
         assert forcing.datablock[2] == [120, 3.45]
+
+    @warnings_enabled
+    def test_create_a_forcing_from_scratch_with_wrong_field(self):
+        forcingmodel = ForcingModel()
+        ts_one = TimeSeries(
+            name="pli_north_0001",
+            verticalposition=VerticalPositionType("ZBed"),
+            quantityunitpair=[
+                QuantityUnitPair(quantity="time", unit="s"),
+                QuantityUnitPair(quantity="salinitybnd", unit="1e-3"),
+            ],
+            timeinterpolation=TimeInterpolation.linear,
+            datablock=[[]],
+        )
+        forcingmodel.forcing.append(ts_one)
+
+        # Should run fine, only with warnings logged.
 
     def test_read_bc_expected_result(self):
         input_str = inspect.cleandoc(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,3 +1,4 @@
+import inspect
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -6,7 +7,7 @@ from typing import Callable, Dict, Union
 import pytest
 from pydantic.error_wrappers import ValidationError
 
-from hydrolib.core.basemodel import DiskOnlyFileModel
+from hydrolib.core.basemodel import DiskOnlyFileModel, warnings_enabled
 from hydrolib.core.io.bc.models import ForcingBase, ForcingModel, QuantityUnitPair
 from hydrolib.core.io.dimr.models import (
     DIMR,
@@ -75,6 +76,11 @@ def test_dimr_model():
 
     assert d.component[1].model is not None
     assert d.component[1].model.save_location.is_file()
+
+
+@warnings_enabled
+def test_dimr_model_warnings_enabled():
+    test_dimr_model()
 
 
 def test_parse_rr_model_returns_correct_model():


### PR DESCRIPTION
Fixes #321.

* Background: When a BaseModel (subclass) has Config.extra == "ignore", then Pydantic silently drops extra fields if the user (accidentally) passes wrong ones.
* A new option will log warning messages in such cases and proceed as normal (Pydantic will still drop these extra fields).
* Set via baseModel.__config__.warn_dropped_extra = True
* A method decorator is available to automatically set this:
```
from hydrolib.core.basemodel import warnings_enabled

@warnings_enabled
def your_function():
```