### PR TITLE
462: fix polyline serializer to print empty trailing comment lines

### DIFF
--- a/hydrolib/core/dflowfm/polyfile/serializer.py
+++ b/hydrolib/core/dflowfm/polyfile/serializer.py
@@ -27,7 +27,7 @@ class Serializer:
             return [
                 "*",
             ]
-        return (f"*{v.rstrip()}" for v in description.content.splitlines())
+        return (f"*{v.rstrip()}" for v in (description.content + "\n").splitlines())
 
     @staticmethod
     def serialize_metadata(metadata: Metadata) -> Iterable[str]:

--- a/tests/data/input/dflowfm_individual_files/test.pli
+++ b/tests/data/input/dflowfm_individual_files/test.pli
@@ -1,0 +1,17 @@
+*
+* description
+* more description
+*
+name1
+2    2
+    1.0    2.0
+    3.0    4.0
+* oneline description (and last polyline will have NO comment)
+name2
+2    2
+    11.0    2.0
+    13.0    4.0
+name3
+2    2
+    21.0    2.0
+    23.0    4.0

--- a/tests/data/input/test.pli
+++ b/tests/data/input/test.pli
@@ -1,6 +1,0 @@
-* description
-* more description
-name
-2    2
-    1.0    2.0
-    3.0    4.0

--- a/tests/dflowfm/test_polyfile.py
+++ b/tests/dflowfm/test_polyfile.py
@@ -642,7 +642,7 @@ name
             assert found_msg == expected_msg
 
     def test_polyfile_can_be_saved_without_errors_and_is_same_as_input(self):
-        infile = test_input_dir / "test.pli"
+        infile = test_input_dir / "dflowfm_individual_files" / "test.pli"
         outfile = test_output_dir / "test.pli"
 
         polyfile = PolyFile(filepath=infile)


### PR DESCRIPTION
Fixes #462 