### PR TITLE
#527: MDU keywords such as 1d2dLinkFile are written to file without comments

### DIFF
--- a/hydrolib/core/dflowfm/ini/models.py
+++ b/hydrolib/core/dflowfm/ini/models.py
@@ -178,7 +178,7 @@ class INIBasedModel(BaseModel, ABC):
             prop = Property(
                 key=key,
                 value=self._convert_value(field_key, value, config, save_settings),
-                comment=getattr(self.comments, key.lower(), None),
+                comment=getattr(self.comments, field_key, None),
             )
             props.append(prop)
         return Section(header=self._header, content=props)

--- a/tests/data/reference/fm/special_3d_settings.mdu
+++ b/tests/data/reference/fm/special_3d_settings.mdu
@@ -25,7 +25,7 @@ frictFile                  =                   # Location of the files with roug
 crossDefFile               =                   # Cross section definitions for all cross section shapes.
 crossLocFile               =                   # Location definitions of the cross sections on a 1D network.
 storageNodeFile            =                   # File containing the specification of storage nodes and/or manholes to add extra storage to 1D models.
-1d2dLinkFile               =
+1d2dLinkFile               =                   # File containing the custom parameterization of 1D-2D links.
 profLocFile                =                   # <*_proflocation.xyz>) x, y, z, z = profile refnumber.
 profDefFile                =                   # <*_profdefinition.def>) definition for all profile nrs.
 profDefXyzFile             =                   # <*_profdefinition.def>) definition for all profile nrs.


### PR DESCRIPTION
Fixes: #527 