### PR TITLE
feat: add missing oldext quantities

### DIFF
--- a/hydrolib/core/dflowfm/extold/models.py
+++ b/hydrolib/core/dflowfm/extold/models.py
@@ -217,8 +217,8 @@ class ExtOldQuantity(str, Enum):
     """Air density"""
     Charnock = "charnock"
     """Charnock coefficient"""
-    DewpointTemperature = "dewpointtemperature"
-    """DewpointTemperature"""
+    Dewpoint = "dewpoint"
+    """Dewpoint temperature"""
     
     # Structure parameters
     Pump = "pump"

--- a/hydrolib/core/dflowfm/extold/models.py
+++ b/hydrolib/core/dflowfm/extold/models.py
@@ -191,7 +191,35 @@ class ExtOldQuantity(str, Enum):
     """Discharge, salinity temperature source-sinks"""
     NudgeSalinityTemperature = "nudge_salinity_temperature"
     """Nudging salinity and temperature"""
-
+    AirPressure = "airpressure"
+    """AirPressure"""
+    StressX = "stressx"
+    """eastward wind stress"""
+    StressY = "stressy"
+    """northward wind stress"""
+    AirTemperature = "airtemperature"
+    """AirTemperature"""
+    Cloudiness = "cloudiness"
+    """Cloudiness, or cloud cover (fraction)"""
+    Humidity = "humidity"
+    """Humidity"""
+    StressXY = "stressxy"
+    """eastward and northward wind stress"""
+    AirpressureStressXStressY = "airpressure_stressx_stressy"
+    """Airpressure, eastward and northward wind stress"""
+    WindSpeed = "wind_speed"
+    """WindSpeed"""
+    WindFromDirection = "wind_from_direction"
+    """WindFromDirection"""
+    DewpointAirTemperatureCloudinessSolarradiation = "dewpoint_airtemperature_cloudiness_solarradiation"
+    """Dewpoint temperature, air temperature, cloudiness, solarradiation"""
+    AirDensity = "airdensity"
+    """Air density"""
+    Charnock = "charnock"
+    """Charnock coefficient"""
+    DewpointTemperature = "dewpointtemperature"
+    """DewpointTemperature"""
+    
     # Structure parameters
     Pump = "pump"
     """Pump capacity"""
@@ -241,27 +269,6 @@ class ExtOldQuantity(str, Enum):
     """Wave significant height"""
     WavePeriod = "waveperiod"
     """Wave period"""
-
-    # missing quantities from https://git.deltares.nl/oss/delft3d/-/blob/main/src/utils_lgpl/ec_module/packages/ec_module/src/ec_provider.F90#L2478-2615
-    AirPressure = "airpressure"
-    StressX = "stressx"  # eastward wind stress
-    StressY = "stressy"  # northward wind stress
-    AirTemperature = "airtemperature"
-    Cloudiness = "cloudiness"  # cloud cover (fraction)
-    Humidity = "humidity"
-
-    # to be implemented in https://issuetracker.deltares.nl/browse/UNST-6593
-    AirDensity = "airdensity"
-    Charnock = "charnock"
-    Dewpoint = "dewpoint"  # TODO: decide on name
-    # DewpointTemperature = "dewpointtemperature"
-
-    # in same file, but not sure if needed
-    # StressXY = "stressxy"
-    # AirpressureStressXStressY = "airpressure_stressx_stressy"
-    # WindSpeed = "wind_speed"
-    # WindFromDirection = "wind_from_direction"
-    # DewPointAirTemperatureCloudinessSolarradiation = "dewpoint_airtemperature_cloudiness_solarradiation"
 
 
 class ExtOldFileType(IntEnum):

--- a/hydrolib/core/dflowfm/extold/models.py
+++ b/hydrolib/core/dflowfm/extold/models.py
@@ -241,29 +241,27 @@ class ExtOldQuantity(str, Enum):
     """Wave significant height"""
     WavePeriod = "waveperiod"
     """Wave period"""
-    
-    #missing quantities from https://git.deltares.nl/oss/delft3d/-/blob/main/src/utils_lgpl/ec_module/packages/ec_module/src/ec_provider.F90#L2478-2615
+
+    # missing quantities from https://git.deltares.nl/oss/delft3d/-/blob/main/src/utils_lgpl/ec_module/packages/ec_module/src/ec_provider.F90#L2478-2615
     AirPressure = "airpressure"
-    StressX = "stressx" #eastward wind stress
-    StressY = "stressy" #northward wind stress
+    StressX = "stressx"  # eastward wind stress
+    StressY = "stressy"  # northward wind stress
     AirTemperature = "airtemperature"
-    Cloudiness = "cloudiness" #cloud cover (fraction)
+    Cloudiness = "cloudiness"  # cloud cover (fraction)
     Humidity = "humidity"
-    
-    #to be implemented in https://issuetracker.deltares.nl/browse/UNST-6593
+
+    # to be implemented in https://issuetracker.deltares.nl/browse/UNST-6593
     AirDensity = "airdensity"
-    Charnock = "charnock" 
-    Dewpoint = "dewpoint" #TODO: decide on name
-    #DewpointTemperature = "dewpointtemperature"
-    
-    
-    #in same file, but not sure if needed
-    #StressXY = "stressxy"
-    #AirpressureStressXStressY = "airpressure_stressx_stressy"
-    #WindSpeed = "wind_speed"
-    #WindFromDirection = "wind_from_direction"
-    #DewPointAirTemperatureCloudinessSolarradiation = "dewpoint_airtemperature_cloudiness_solarradiation"
-    
+    Charnock = "charnock"
+    Dewpoint = "dewpoint"  # TODO: decide on name
+    # DewpointTemperature = "dewpointtemperature"
+
+    # in same file, but not sure if needed
+    # StressXY = "stressxy"
+    # AirpressureStressXStressY = "airpressure_stressx_stressy"
+    # WindSpeed = "wind_speed"
+    # WindFromDirection = "wind_from_direction"
+    # DewPointAirTemperatureCloudinessSolarradiation = "dewpoint_airtemperature_cloudiness_solarradiation"
 
 
 class ExtOldFileType(IntEnum):

--- a/hydrolib/core/dflowfm/extold/models.py
+++ b/hydrolib/core/dflowfm/extold/models.py
@@ -241,6 +241,30 @@ class ExtOldQuantity(str, Enum):
     """Wave significant height"""
     WavePeriod = "waveperiod"
     """Wave period"""
+    
+    #missing quantities from https://git.deltares.nl/oss/delft3d/-/blob/main/src/utils_lgpl/ec_module/packages/ec_module/src/ec_provider.F90#L2478-2615
+    StressX = "stressx" #eastward wind stress
+    StressY = "stressy" #northward wind stress
+    StressXY = "stressxy"
+    
+    AirPressure = "airpressure"
+    AtmosphericPressure = "atmosphericpressure"
+    """Atmospheric pressure"""
+    Charnock = "charnock" #TODO: to be implemented in https://issuetracker.deltares.nl/browse/UNST-6593
+    """Charnock"""
+    Dewpoint = "dewpoint" #TODO: to be implemented in https://issuetracker.deltares.nl/browse/UNST-6593, decide on name
+    #DewpointTemperature = "dewpointtemperature"
+    """DewpointTemperature"""
+    AirTemperature = "airtemperature"
+    Cloudiness = "cloudiness" #cloud cover (fraction)
+    Humidity = "humidity"
+    
+    #in same file, but not sure if needed
+    #AirpressureStressXStressY = "airpressure_stressx_stressy"
+    #WindSpeed = "wind_speed"
+    #WindFromDirection = "wind_from_direction"
+    #DewPointAirTemperatureCloudinessSolarradiation = "dewpoint_airtemperature_cloudiness_solarradiation"
+    
 
 
 class ExtOldFileType(IntEnum):

--- a/hydrolib/core/dflowfm/extold/models.py
+++ b/hydrolib/core/dflowfm/extold/models.py
@@ -221,7 +221,7 @@ class ExtOldQuantity(str, Enum):
     """Charnock coefficient"""
     Dewpoint = "dewpoint"
     """Dewpoint temperature"""
-    
+
     # Structure parameters
     Pump = "pump"
     """Pump capacity"""

--- a/hydrolib/core/dflowfm/extold/models.py
+++ b/hydrolib/core/dflowfm/extold/models.py
@@ -243,23 +243,22 @@ class ExtOldQuantity(str, Enum):
     """Wave period"""
     
     #missing quantities from https://git.deltares.nl/oss/delft3d/-/blob/main/src/utils_lgpl/ec_module/packages/ec_module/src/ec_provider.F90#L2478-2615
+    AirPressure = "airpressure"
     StressX = "stressx" #eastward wind stress
     StressY = "stressy" #northward wind stress
-    StressXY = "stressxy"
-    
-    AirPressure = "airpressure"
-    AtmosphericPressure = "atmosphericpressure"
-    """Atmospheric pressure"""
-    Charnock = "charnock" #TODO: to be implemented in https://issuetracker.deltares.nl/browse/UNST-6593
-    """Charnock"""
-    Dewpoint = "dewpoint" #TODO: to be implemented in https://issuetracker.deltares.nl/browse/UNST-6593, decide on name
-    #DewpointTemperature = "dewpointtemperature"
-    """DewpointTemperature"""
     AirTemperature = "airtemperature"
     Cloudiness = "cloudiness" #cloud cover (fraction)
     Humidity = "humidity"
     
+    #to be implemented in https://issuetracker.deltares.nl/browse/UNST-6593
+    AirDensity = "airdensity"
+    Charnock = "charnock" 
+    Dewpoint = "dewpoint" #TODO: decide on name
+    #DewpointTemperature = "dewpointtemperature"
+    
+    
     #in same file, but not sure if needed
+    #StressXY = "stressxy"
     #AirpressureStressXStressY = "airpressure_stressx_stressy"
     #WindSpeed = "wind_speed"
     #WindFromDirection = "wind_from_direction"


### PR DESCRIPTION
I added all quantities from [ec_provider.F90](https://git.deltares.nl/oss/delft3d/-/blob/main/src/utils_lgpl/ec_module/packages/ec_module/src/ec_provider.F90#L2478-2615) that were missing in hydrolib-core in this PR. I have also added three new quantities that will be implemented in the linked [UNST-6593](https://issuetracker.deltares.nl/browse/UNST-6593)