### PR TITLE
use new contacts_set from meshkernel 4.0.2

### DIFF
--- a/hydrolib/core/dflowfm/net/reader.py
+++ b/hydrolib/core/dflowfm/net/reader.py
@@ -10,6 +10,7 @@ import netCDF4 as nc
 import numpy as np
 
 from hydrolib.core.basemodel import BaseModel
+from meshkernel import Contacts
 
 if TYPE_CHECKING:
     from hydrolib.core.dflowfm.net.models import Link1d2d, Mesh1d, Mesh2d
@@ -123,16 +124,11 @@ class UgridReader:
         for meshkey, nckey in self._explorer.link1d2d_var_name_mapping.items():
             setattr(link1d2d, meshkey, self._read_nc_attribute(ds[nckey]))
 
-        # TODO: setting contacts is not possible yet in meshkernel
-        # https://github.com/Deltares/MeshKernelPy/issues/107
-        # https://github.com/Deltares/HYDROLIB-core/issues/575
-        # so misalignment between link1d2d.link1d2d and
-        # empty _link1d2d.meshkernel.contacts_get().mesh2d_indices
-        # mesh1d_indices = link1d2d.link1d2d[:,0]
-        # mesh2d_indices = link1d2d.link1d2d[:,1]
-        # import meshkernel as mk
-        # contacts = mk.Contacts(mesh1d_indices=mesh1d_indices, mesh2d_indices=mesh2d_indices)
-        # link1d2d.meshkernel.contacts_set(contacts)
+        # set contacts on meshkernel, use .copy() to avoid strided arrays
+        mesh1d_indices = link1d2d.link1d2d[:,0].copy()
+        mesh2d_indices = link1d2d.link1d2d[:,1].copy()
+        contacts = Contacts(mesh1d_indices=mesh1d_indices, mesh2d_indices=mesh2d_indices)
+        link1d2d.meshkernel.contacts_set(contacts)
 
         ds.close()
 

--- a/tests/dflowfm/test_net.py
+++ b/tests/dflowfm/test_net.py
@@ -160,10 +160,8 @@ def test_create_1d_2d_1d2d():
     network2_con_m1d = network2._link1d2d.meshkernel.contacts_get().mesh1d_indices
     network2_con_m2d = network2._link1d2d.meshkernel.contacts_get().mesh2d_indices
     assert network2_link1d2d.shape == (21, 2)
-    # TODO: below asserts fail, since the meshkernel contacts are not set upon reading
-    # https://github.com/Deltares/HYDROLIB-core/issues/575
-    # assert network2_con_m1d.size == 21
-    # assert network2_con_m2d.size == 21
+    assert network2_con_m1d.size == 21
+    assert network2_con_m2d.size == 21
 
     # plot both networks
     import matplotlib.pyplot as plt


### PR DESCRIPTION
This PR uses a `contacts_set()`, which is newly implemented in meshkernel 4.0.0 (4.0.2). The testbank should be green after merging https://github.com/Deltares/HYDROLIB-core/pull/596 with main and updating this branch.