### PR TITLE
feat: reduce rereading cached files during init

### DIFF
--- a/hydrolib/core/basemodel.py
+++ b/hydrolib/core/basemodel.py
@@ -431,6 +431,7 @@ class CachedFileModel:
         self._model = model
         self._checksum = checksum
 
+
 class FileModelCache:
     """
     FileModelCache provides a simple structure to register and retrieve FileModel
@@ -840,7 +841,7 @@ class FileModel(BaseModel, ABC):
                 if not context.is_content_changed(filepath):
                     cls._has_been_loaded_from_cache = True
                     return file_model
-            
+
             cls._has_been_loaded_from_cache = False
             return super().__new__(cls)
 

--- a/hydrolib/core/basemodel.py
+++ b/hydrolib/core/basemodel.py
@@ -403,22 +403,24 @@ class FilePathResolver:
         if relative_mode == ResolveRelativeMode.ToAnchor:
             self._anchors.pop()
 
-class CachedPathFileModelData():
 
-    _model : "FileModel"
-    _checksum : str
-    
+class CachedPathFileModelData:
+
+    _model: "FileModel"
+    _checksum: str
+
     @property
     def model(self) -> "FileModel":
         return self._model
-    
+
     @property
     def checksum(self) -> str:
         return self._checksum
 
-    def __init__(self, model : "FileModel", checksum : str) -> None:
+    def __init__(self, model: "FileModel", checksum: str) -> None:
         self._model = model
         self._checksum = checksum
+
 
 class FileModelCache:
     """
@@ -461,10 +463,10 @@ class FileModelCache:
             bool: Whether or not the cache is empty.
         """
         return not any(self._cache_dict)
-    
-    def exists(self, path : Path) -> bool:
+
+    def exists(self, path: Path) -> bool:
         """Whether or not the filepath is in the cache.
-        
+
         Args:
             path (Path): The path to verify if it is already added in the cache.
 
@@ -472,10 +474,10 @@ class FileModelCache:
             bool: Whether or not the path is in the cache.
         """
         return path in self._cache_dict
-    
-    def has_changed(self, path : Path) -> bool:
+
+    def has_changed(self, path: Path) -> bool:
         """Whether or not the file in the filepath has changed from the cache.
-        
+
         Args:
             path (Path): The path to verify verify against.
 
@@ -487,12 +489,13 @@ class FileModelCache:
         """
         if not self.exists(path):
             return True
-        
+
         checksum = self._get_checksum(path)
         return checksum != self._cache_dict.get(path).checksum
-    
-    def _get_checksum(self, path : Path) -> str:
+
+    def _get_checksum(self, path: Path) -> str:
         return FileChecksumCalculator.calculate_checksum(path)
+
 
 class ModelSaveSettings:
     """A class that holds the global settings for model saving."""
@@ -721,7 +724,7 @@ class FileLoadContext:
             file_path, self.load_settings.path_style
         )
         return Path(converted_file_path)
-    
+
     def is_content_changed(self, path: Path) -> bool:
         """Verify if the path is already known and if the content have changed.
 
@@ -731,7 +734,7 @@ class FileLoadContext:
         Args:
             path (Path): The relative path from which the model was loaded.
             model (FileModel): The loaded model.
-            
+
         Returns:
             True when the content from the path on the location has been changed.
             False when the content from the path is not priorly cached.
@@ -739,7 +742,6 @@ class FileLoadContext:
         """
         absolute_path = self._path_resolver.resolve(path)
         return self._cache.has_changed(absolute_path)
-        
 
 
 @contextmanager
@@ -878,7 +880,7 @@ class FileModel(BaseModel, ABC):
                 filepath = self._get_updated_file_path(filepath, loading_path)
 
             logger.info(f"Loading data from {filepath}")
-            
+
             data = context.retrieve_model(filepath)
             if context.is_content_changed(filepath):
                 data = self._load(loading_path)

--- a/hydrolib/core/basemodel.py
+++ b/hydrolib/core/basemodel.py
@@ -865,7 +865,7 @@ class FileModel(BaseModel, ABC):
         """
         if self._has_been_loaded_from_cache:
             return
-        
+
         if not filepath:
             super().__init__(*args, **kwargs)
             return

--- a/hydrolib/core/basemodel.py
+++ b/hydrolib/core/basemodel.py
@@ -408,7 +408,7 @@ class CachedPathFileModelData:
     """
     CachedPathFileModelData provides a simple structure to keep the Filemodel and checksum together.
     """
-    
+
     _model: "FileModel"
     _checksum: str
 
@@ -419,7 +419,7 @@ class CachedPathFileModelData:
 
     @property
     def checksum(self) -> str:
-        """"Checksum of the file the filemodel is based on."""
+        """ "Checksum of the file the filemodel is based on."""
         return self._checksum
 
     def __init__(self, model: "FileModel", checksum: str) -> None:

--- a/hydrolib/core/basemodel.py
+++ b/hydrolib/core/basemodel.py
@@ -837,11 +837,12 @@ class FileModel(BaseModel, ABC):
         filepath = FileModel._change_to_path(filepath)
         with file_load_context() as context:
             if (file_model := context.retrieve_model(filepath)) is not None:
-                cls._has_been_loaded_from_cache = True
-                return file_model
-            else:
-                cls._has_been_loaded_from_cache = False
-                return super().__new__(cls)
+                if not context.is_content_changed(filepath):
+                    cls._has_been_loaded_from_cache = True
+                    return file_model
+            
+            cls._has_been_loaded_from_cache = False
+            return super().__new__(cls)
 
     def __init__(
         self,

--- a/hydrolib/core/basemodel.py
+++ b/hydrolib/core/basemodel.py
@@ -807,13 +807,12 @@ class FileModel(BaseModel, ABC):
                 filepath = self._get_updated_file_path(filepath, loading_path)
 
             logger.info(f"Loading data from {filepath}")
-
-            data = self._load(loading_path)
-            context.register_model(filepath, self)
-            data["filepath"] = filepath
+            
+            if (data := context.retrieve_model(filepath)) is None:
+                data = self._load(loading_path)
+                context.register_model(filepath, self)
+                data["filepath"] = filepath
             kwargs.update(data)
-
-            context.register_model(filepath, self)
 
             # Note: the relative mode needs to be obtained from the data directly
             # because self._relative_mode has not been resolved yet (this is done as

--- a/hydrolib/core/basemodel.py
+++ b/hydrolib/core/basemodel.py
@@ -405,16 +405,21 @@ class FilePathResolver:
 
 
 class CachedPathFileModelData:
-
+    """
+    CachedPathFileModelData provides a simple structure to keep the Filemodel and checksum together.
+    """
+    
     _model: "FileModel"
     _checksum: str
 
     @property
     def model(self) -> "FileModel":
+        """FileModel."""
         return self._model
 
     @property
     def checksum(self) -> str:
+        """"Checksum of the file the filemodel is based on."""
         return self._checksum
 
     def __init__(self, model: "FileModel", checksum: str) -> None:

--- a/hydrolib/core/basemodel.py
+++ b/hydrolib/core/basemodel.py
@@ -446,10 +446,10 @@ class FileModelCache:
                 The FileModel associated with the Path if it has been registered
                 before, otherwise None.
         """
-        fileModel = self._cache_dict.get(path, None)
-        if fileModel is None:
+        file_model = self._cache_dict.get(path, None)
+        if file_model is None:
             return None
-        return fileModel.model
+        return file_model.model
 
     def register_model(self, path: Path, model: "FileModel") -> None:
         """Register the model with the specified path in this FileModelCache.

--- a/hydrolib/core/utils.py
+++ b/hydrolib/core/utils.py
@@ -302,18 +302,19 @@ class FilePathStyleConverter:
 
         return posix_path
 
+
 class FileChecksumCalculator:
     """
     FileChecksumCalculator calculator used to calculate the checksum of a file.
     """
-    
+
     @staticmethod
     def calculate_checksum(filepath: Path) -> Optional[str]:
         """Calculate the checksum of the file from the given filepath.
-        
+
         Args:
             filepath (Path): The filepath to the file for which the checksum will be calculated.
-            
+
         Returns:
             [Optional[str]]:
                 The checksum of the file.
@@ -321,11 +322,11 @@ class FileChecksumCalculator:
         """
         if not filepath.exists() or not filepath.is_file():
             return None
-        
+
         return FileChecksumCalculator._calculate_sha256_checksum(filepath)
-    
+
     @staticmethod
-    def _calculate_sha256_checksum(filepath : Path) -> str:
+    def _calculate_sha256_checksum(filepath: Path) -> str:
         sha256_hash = sha256()
         with open(filepath, "rb") as file:
             for chunk in iter(lambda: file.read(4096), b""):

--- a/hydrolib/core/utils.py
+++ b/hydrolib/core/utils.py
@@ -1,6 +1,7 @@
 import platform
 import re
 from enum import Enum, auto
+from hashlib import sha256
 from operator import eq, ge, gt, le, lt, ne
 from pathlib import Path
 from typing import Any, Callable, List, Optional
@@ -300,3 +301,33 @@ class FilePathStyleConverter:
         posix_path = posix_root + "/".join(parts)
 
         return posix_path
+
+class FileChecksumCalculator:
+    """
+    FileChecksumCalculator calculator used to calculate the checksum of a file.
+    """
+    
+    @staticmethod
+    def calculate_checksum(filepath: Path) -> Optional[str]:
+        """Calculate the checksum of the file from the given filepath.
+        
+        Args:
+            filepath (Path): The filepath to the file for which the checksum will be calculated.
+            
+        Returns:
+            [Optional[str]]:
+                The checksum of the file.
+                When the filepath doesn't exist or the filepath isn't a file, None.
+        """
+        if not filepath.exists() or not filepath.is_file():
+            return None
+        
+        return FileChecksumCalculator._calculate_sha256_checksum(filepath)
+    
+    @staticmethod
+    def _calculate_sha256_checksum(filepath : Path) -> str:
+        sha256_hash = sha256()
+        with open(filepath, "rb") as file:
+            for chunk in iter(lambda: file.read(4096), b""):
+                sha256_hash.update(chunk)
+        return sha256_hash.hexdigest()

--- a/hydrolib/core/utils.py
+++ b/hydrolib/core/utils.py
@@ -1,7 +1,7 @@
 import platform
 import re
 from enum import Enum, auto
-from hashlib import sha256
+from hashlib import md5
 from operator import eq, ge, gt, le, lt, ne
 from pathlib import Path
 from typing import Any, Callable, List, Optional
@@ -323,12 +323,12 @@ class FileChecksumCalculator:
         if not filepath.exists() or not filepath.is_file():
             return None
 
-        return FileChecksumCalculator._calculate_sha256_checksum(filepath)
+        return FileChecksumCalculator._calculate_md5_checksum(filepath)
 
     @staticmethod
-    def _calculate_sha256_checksum(filepath: Path) -> str:
-        sha256_hash = sha256()
+    def _calculate_md5_checksum(filepath: Path) -> str:
+        md5_hash = md5()
         with open(filepath, "rb") as file:
             for chunk in iter(lambda: file.read(4096), b""):
-                sha256_hash.update(chunk)
-        return sha256_hash.hexdigest()
+                md5_hash.update(chunk)
+        return md5_hash.hexdigest()

--- a/tests/test_basemodel.py
+++ b/tests/test_basemodel.py
@@ -543,13 +543,13 @@ class TestFileModelCache:
         model = DIMR()
         cache.register_model(path, model)
 
-        assert cache.exists(path)
+        assert cache._exists(path)
 
     def test_no_registed_model_when_cache_exists_returns_false(self, tmp_path):
         cache = FileModelCache()
         path = tmp_path / "some-dimr.xml"
 
-        assert not cache.exists(path)
+        assert not cache._exists(path)
 
     def test_has_changed_on_unchanged_file_returns_false(self, tmp_path: Path):
         cache = FileModelCache()

--- a/tests/test_basemodel.py
+++ b/tests/test_basemodel.py
@@ -351,29 +351,37 @@ class TestFileModel:
         model = FMModel(given_path)
         assert model.filepath == expected_path
 
+
 class TestFileLoadContextReusingCachedFilesDuringInit:
-    
-    def test_loading_file_referenced_multiple_times_only_loads_once(self, tmp_path : Path):
+    def test_loading_file_referenced_multiple_times_only_loads_once(
+        self, tmp_path: Path
+    ):
         bc_file_name = "bc_file.bc"
-        ext_file = self.create_ext_file_with_5_times_bc_file_reused(tmp_path, bc_file_name)
+        ext_file = self.create_ext_file_with_5_times_bc_file_reused(
+            tmp_path, bc_file_name
+        )
         self.create_bc_file(tmp_path, bc_file_name)
-        
-        with patch.object(ForcingModel, '_load') as bc_mocked_load:
+
+        with patch.object(ForcingModel, "_load") as bc_mocked_load:
             ExtModel(ext_file)
             assert bc_mocked_load.call_count == 1
-            
-    def test_loading_multiple_files_referenced_multiple_times_only_loads_the_respective_files_once(self, tmp_path : Path):
+
+    def test_loading_multiple_files_referenced_multiple_times_only_loads_the_respective_files_once(
+        self, tmp_path: Path
+    ):
         first_bc_file_name = "bc_file.bc"
         second_bc_file_name = "bc_file2.bc"
-        ext_file = self.create_ext_file_with_2_times_2_bc_file_reused(tmp_path, first_bc_file_name, second_bc_file_name)
+        ext_file = self.create_ext_file_with_2_times_2_bc_file_reused(
+            tmp_path, first_bc_file_name, second_bc_file_name
+        )
         self.create_bc_file(tmp_path, first_bc_file_name)
         self.create_bc_file(tmp_path, second_bc_file_name)
-        
-        with patch.object(ForcingModel, '_load') as bc_mocked_load:
+
+        with patch.object(ForcingModel, "_load") as bc_mocked_load:
             ExtModel(ext_file)
             assert bc_mocked_load.call_count == 2
 
-    def create_bc_file(self, tmp_path : Path, name : str):
+    def create_bc_file(self, tmp_path: Path, name: str):
         bc_file = tmp_path / name
         bc_file_data = """[forcing]
 Name                = global
@@ -400,8 +408,8 @@ Unit                = mm day-1
 3000.000000     0.0000000
 """
         bc_file.write_text(bc_file_data)
-        
-    def change_bc_file(self, tmp_path : Path, name : str):
+
+    def change_bc_file(self, tmp_path: Path, name: str):
         bc_file = tmp_path / name
         bc_file_data = """[forcing]
 Name                = little_change_to_the_file
@@ -429,7 +437,9 @@ Unit                = mm day-1
 """
         bc_file.write_text(bc_file_data)
 
-    def create_ext_file_with_5_times_bc_file_reused(self, tmp_path : Path, name : str) -> Path:
+    def create_ext_file_with_5_times_bc_file_reused(
+        self, tmp_path: Path, name: str
+    ) -> Path:
         ext_file = tmp_path / "ext_file.ext"
         ext_file_data = f"""[boundary]
 quantity=dischargebnd
@@ -451,11 +461,13 @@ forcingfile={name}
 quantity=temperaturebnd
 locationfile=boundary_conditions/rmm_zeerand_v3.pli
 forcingfile={name}"""
-        
+
         ext_file.write_text(ext_file_data)
         return ext_file
-    
-    def create_ext_file_with_2_times_2_bc_file_reused(self, tmp_path : Path, name : str, name2 : str) -> Path:
+
+    def create_ext_file_with_2_times_2_bc_file_reused(
+        self, tmp_path: Path, name: str, name2: str
+    ) -> Path:
         ext_file = tmp_path / "ext_file.ext"
         ext_file_data = f"""[boundary]
 quantity=dischargebnd
@@ -473,11 +485,10 @@ forcingfile={name2}
 quantity=salinitybnd
 locationfile=boundary_conditions/rmm_zeerand_v3.pli
 forcingfile={name2}"""
-        
+
         ext_file.write_text(ext_file_data)
         return ext_file
-        
-        
+
 
 class TestContextManagerFileLoadContext:
     def test_context_is_created_and_disposed_properly(self):

--- a/tests/test_basemodel.py
+++ b/tests/test_basemodel.py
@@ -366,6 +366,25 @@ class TestFileLoadContextReusingCachedFilesDuringInit:
             ExtModel(ext_file)
             assert bc_mocked_load.call_count == 1
 
+    def test_loading_file_referenced_multiple_times_has_loaded_data_as_same_instance(
+        self, tmp_path: Path
+    ):
+        bc_file_name = "bc_file.bc"
+        ext_file = self.create_ext_file_with_5_times_bc_file_reused(
+            tmp_path, bc_file_name
+        )
+        self.create_bc_file(tmp_path, bc_file_name)
+        
+        model = ExtModel(ext_file)
+        
+        savepath = tmp_path / "tim.ext"
+        model.save(savepath, recurse=True)
+        assert model
+        assert model.boundary[0].forcingfile is model.boundary[1].forcingfile
+        assert model.boundary[1].forcingfile is model.boundary[2].forcingfile
+        assert model.boundary[2].forcingfile is model.boundary[3].forcingfile
+        assert model.boundary[3].forcingfile is model.boundary[4].forcingfile
+
     def test_loading_multiple_files_referenced_multiple_times_only_loads_the_respective_files_once(
         self, tmp_path: Path
     ):

--- a/tests/test_basemodel.py
+++ b/tests/test_basemodel.py
@@ -377,9 +377,6 @@ class TestFileLoadContextReusingCachedFilesDuringInit:
         
         model = ExtModel(ext_file)
         
-        savepath = tmp_path / "tim.ext"
-        model.save(savepath, recurse=True)
-        assert model
         assert model.boundary[0].forcingfile is model.boundary[1].forcingfile
         assert model.boundary[1].forcingfile is model.boundary[2].forcingfile
         assert model.boundary[2].forcingfile is model.boundary[3].forcingfile

--- a/tests/test_basemodel.py
+++ b/tests/test_basemodel.py
@@ -380,6 +380,44 @@ class TestFileModelCache:
 
         assert cache.retrieve_model(path) is model
 
+    def test_registed_model_when_cache_exists_returns_true(self, tmp_path):
+        cache = FileModelCache()
+        path = tmp_path / "some-dimr.xml"
+        model = DIMR()
+        cache.register_model(path, model)
+        
+        assert cache.exists(path)
+        
+    def test_no_registed_model_when_cache_exists_returns_false(self, tmp_path):
+        cache = FileModelCache()
+        path = tmp_path / "some-dimr.xml"
+        
+        assert not cache.exists(path)
+        
+    def test_has_changed_on_unchanged_file_returns_false(self, tmp_path : Path):
+        cache = FileModelCache()
+        path = tmp_path / "some-dimr.xml"
+        path.write_text("Hello World")
+        model = DIMR()
+        cache.register_model(path, model)
+        
+        assert not cache.has_changed(path)
+        
+    def test_has_changed_on_changed_file_returns_true(self, tmp_path : Path):
+        cache = FileModelCache()
+        path = tmp_path / "some-dimr.xml"
+        path.write_text("Hello World")
+        model = DIMR()
+        cache.register_model(path, model)
+        path.write_text("Hello World second time")
+        
+        assert cache.has_changed(path)
+        
+    def test_has_changed_when_no_registed_model_returns_true(self, tmp_path : Path):
+        cache = FileModelCache()
+        path = tmp_path / "some-dimr.xml"
+        
+        assert cache.has_changed(path)
 
 class TestFilePathResolver:
     @pytest.mark.parametrize(
@@ -629,6 +667,31 @@ class TestFileLoadContext:
         assert context.load_settings.recurse == first_bool
         assert context.load_settings.resolve_casing == first_bool
         assert context.load_settings.path_style == first_path_style
+        
+    def test_is_content_changed_on_unchanged_file_returns_false(self, tmp_path : Path):
+        context = FileLoadContext()
+        path = tmp_path / "some-dimr.xml"
+        path.write_text("Hello World")
+        model = DIMR()
+        context.register_model(path, model)
+        
+        assert not context.is_content_changed(path)
+        
+    def test_is_content_changed_on_changed_file_returns_true(self, tmp_path : Path):
+        context = FileLoadContext()
+        path = tmp_path / "some-dimr.xml"
+        path.write_text("Hello World")
+        model = DIMR()
+        context.register_model(path, model)
+        path.write_text("Hello World second time")
+        
+        assert context.is_content_changed(path)
+        
+    def test_is_content_changed_when_no_registed_model_returns_true(self, tmp_path : Path):
+        context = FileLoadContext()
+        path = tmp_path / "some-dimr.xml"
+        
+        assert context.is_content_changed(path)
 
 
 class TestDiskOnlyFileModel:

--- a/tests/test_basemodel.py
+++ b/tests/test_basemodel.py
@@ -385,39 +385,40 @@ class TestFileModelCache:
         path = tmp_path / "some-dimr.xml"
         model = DIMR()
         cache.register_model(path, model)
-        
+
         assert cache.exists(path)
-        
+
     def test_no_registed_model_when_cache_exists_returns_false(self, tmp_path):
         cache = FileModelCache()
         path = tmp_path / "some-dimr.xml"
-        
+
         assert not cache.exists(path)
-        
-    def test_has_changed_on_unchanged_file_returns_false(self, tmp_path : Path):
+
+    def test_has_changed_on_unchanged_file_returns_false(self, tmp_path: Path):
         cache = FileModelCache()
         path = tmp_path / "some-dimr.xml"
         path.write_text("Hello World")
         model = DIMR()
         cache.register_model(path, model)
-        
+
         assert not cache.has_changed(path)
-        
-    def test_has_changed_on_changed_file_returns_true(self, tmp_path : Path):
+
+    def test_has_changed_on_changed_file_returns_true(self, tmp_path: Path):
         cache = FileModelCache()
         path = tmp_path / "some-dimr.xml"
         path.write_text("Hello World")
         model = DIMR()
         cache.register_model(path, model)
         path.write_text("Hello World second time")
-        
+
         assert cache.has_changed(path)
-        
-    def test_has_changed_when_no_registed_model_returns_true(self, tmp_path : Path):
+
+    def test_has_changed_when_no_registed_model_returns_true(self, tmp_path: Path):
         cache = FileModelCache()
         path = tmp_path / "some-dimr.xml"
-        
+
         assert cache.has_changed(path)
+
 
 class TestFilePathResolver:
     @pytest.mark.parametrize(
@@ -667,30 +668,32 @@ class TestFileLoadContext:
         assert context.load_settings.recurse == first_bool
         assert context.load_settings.resolve_casing == first_bool
         assert context.load_settings.path_style == first_path_style
-        
-    def test_is_content_changed_on_unchanged_file_returns_false(self, tmp_path : Path):
+
+    def test_is_content_changed_on_unchanged_file_returns_false(self, tmp_path: Path):
         context = FileLoadContext()
         path = tmp_path / "some-dimr.xml"
         path.write_text("Hello World")
         model = DIMR()
         context.register_model(path, model)
-        
+
         assert not context.is_content_changed(path)
-        
-    def test_is_content_changed_on_changed_file_returns_true(self, tmp_path : Path):
+
+    def test_is_content_changed_on_changed_file_returns_true(self, tmp_path: Path):
         context = FileLoadContext()
         path = tmp_path / "some-dimr.xml"
         path.write_text("Hello World")
         model = DIMR()
         context.register_model(path, model)
         path.write_text("Hello World second time")
-        
+
         assert context.is_content_changed(path)
-        
-    def test_is_content_changed_when_no_registed_model_returns_true(self, tmp_path : Path):
+
+    def test_is_content_changed_when_no_registed_model_returns_true(
+        self, tmp_path: Path
+    ):
         context = FileLoadContext()
         path = tmp_path / "some-dimr.xml"
-        
+
         assert context.is_content_changed(path)
 
 

--- a/tests/test_basemodel.py
+++ b/tests/test_basemodel.py
@@ -374,9 +374,9 @@ class TestFileLoadContextReusingCachedFilesDuringInit:
             tmp_path, bc_file_name
         )
         self.create_bc_file(tmp_path, bc_file_name)
-        
+
         model = ExtModel(ext_file)
-        
+
         assert model.boundary[0].forcingfile is model.boundary[1].forcingfile
         assert model.boundary[1].forcingfile is model.boundary[2].forcingfile
         assert model.boundary[2].forcingfile is model.boundary[3].forcingfile

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -344,22 +344,28 @@ class TestFilePathStyleConverter:
                     "from_os", source_path, PathStyle.UNIXLIKE, exp_target_path
                 )
 
+
 class TestFileChecksumCalculator:
-    def test_calculating_checksum_of_default_file_gives_expected_checksum(self, tmp_path: Path):
+    def test_calculating_checksum_of_default_file_gives_expected_checksum(
+        self, tmp_path: Path
+    ):
         default_file = tmp_path / "default_file.txt"
         default_file.write_text("Hello World")
-        expected_checksum = 'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e'
-        
+        expected_checksum = (
+            "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e"
+        )
+
         calculated_checksum = FileChecksumCalculator.calculate_checksum(default_file)
         assert calculated_checksum == expected_checksum
-        
+
     def test_calculating_checksum_of_non_existing_file_gives_none(self, tmp_path: Path):
         non_existing_file = tmp_path / "non_existing_file.txt"
-        
-        calculated_checksum = FileChecksumCalculator.calculate_checksum(non_existing_file)
+
+        calculated_checksum = FileChecksumCalculator.calculate_checksum(
+            non_existing_file
+        )
         assert calculated_checksum is None
-        
+
     def test_calculating_checksum_of_folder_gives_none(self, tmp_path: Path):
         calculated_checksum = FileChecksumCalculator.calculate_checksum(tmp_path)
         assert calculated_checksum is None
-        

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ import pytest
 
 from hydrolib.core.dflowfm.mdu.models import Geometry, Output
 from hydrolib.core.utils import (
+    FileChecksumCalculator,
     FilePathStyleConverter,
     PathStyle,
     get_substring_between,
@@ -342,3 +343,23 @@ class TestFilePathStyleConverter:
                 TestFilePathStyleConverter.run_and_assert_os_path_style_converter(
                     "from_os", source_path, PathStyle.UNIXLIKE, exp_target_path
                 )
+
+class TestFileChecksumCalculator:
+    def test_calculating_checksum_of_default_file_gives_expected_checksum(self, tmp_path: Path):
+        default_file = tmp_path / "default_file.txt"
+        default_file.write_text("Hello World")
+        expected_checksum = 'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e'
+        
+        calculated_checksum = FileChecksumCalculator.calculate_checksum(default_file)
+        assert calculated_checksum == expected_checksum
+        
+    def test_calculating_checksum_of_non_existing_file_gives_none(self, tmp_path: Path):
+        non_existing_file = tmp_path / "non_existing_file.txt"
+        
+        calculated_checksum = FileChecksumCalculator.calculate_checksum(non_existing_file)
+        assert calculated_checksum is None
+        
+    def test_calculating_checksum_of_folder_gives_none(self, tmp_path: Path):
+        calculated_checksum = FileChecksumCalculator.calculate_checksum(tmp_path)
+        assert calculated_checksum is None
+        

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -351,9 +351,7 @@ class TestFileChecksumCalculator:
     ):
         default_file = tmp_path / "default_file.txt"
         default_file.write_text("Hello World")
-        expected_checksum = (
-            "b10a8db164e0754105b7a99be72e3fe5"
-        )
+        expected_checksum = "b10a8db164e0754105b7a99be72e3fe5"
 
         calculated_checksum = FileChecksumCalculator.calculate_checksum(default_file)
         assert calculated_checksum == expected_checksum

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -352,7 +352,7 @@ class TestFileChecksumCalculator:
         default_file = tmp_path / "default_file.txt"
         default_file.write_text("Hello World")
         expected_checksum = (
-            "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e"
+            "b10a8db164e0754105b7a99be72e3fe5"
         )
 
         calculated_checksum = FileChecksumCalculator.calculate_checksum(default_file)


### PR DESCRIPTION
#354 

- [x] The existing caching should be expanded to also be used with initialization reading, instead of only newing objects.
- [x] The existing caching should be expanded to verify if a file has changed before returning the cache data.
- [x] When the file has changed a new cache of the file should be made.

### Note for reviewer
Im not fully sure how the @contextmanager functions.
It seems to create new instance for caching for each model which is initialized.

I could not setup a good test to test these steps:
Reading a file --> updating and changing the model it is read to --> saving the file --> reading the same file, changed data is read, since the file has been updated while the application is running.
Since there is not any other way to read the file as a user except for via the ctor.
The _load method could be used, but this is "private" and should not be used by the user.
This method also does not make use of the caching.