### PR TITLE
chore: correct mdu.geometry.stretchtype default value

### DIFF
--- a/hydrolib/core/dflowfm/mdu/models.py
+++ b/hydrolib/core/dflowfm/mdu/models.py
@@ -2079,7 +2079,7 @@ class Geometry(INIBasedModel):
     )
     dxmin1d: float = Field(0.001, alias="dxmin1D")
     uniformtyp1dstreetinlets: int = Field(-2, alias="uniformTyp1DStreetInlets")
-    stretchtype: int = Field(1, alias="stretchType")
+    stretchtype: int = Field(-1, alias="stretchType")
     zlaybot: float = Field(-999.0, alias="zlayBot")
     zlaytop: float = Field(-999.0, alias="zlayTop")
     uniformheight1d: float = Field(3.0, alias="uniformHeight1D")

--- a/tests/data/reference/fm/special_3d_settings.mdu
+++ b/tests/data/reference/fm/special_3d_settings.mdu
@@ -69,7 +69,7 @@ slotw2D                        = 0.001             # Minimum slotwidth 2D [m].
 uniformHeight1DRoofGutterPipes = 0.1               # Uniform height for roof gutter pipes [m].
 dxmin1D                        = 0.001             # Minimum 1D link length [m].
 uniformTyp1DStreetInlets       = -2                # Uniform cross section type for street inlets (1: circle, 2: rectangle, -2: closed rectangle).
-stretchType                    = 1                 # Stretching type for non-uniform layers, 1=user defined, 2=exponential, otherwise=uniform.
+stretchType                    = -1                # Stretching type for non-uniform layers, 1=user defined, 2=exponential, otherwise=uniform.
 zlayBot                        = -999.0            # if specified, first z-layer starts from zlaybot [ ], if not, it starts from the lowest bed point.
 zlayTop                        = -999.0            # if specified, highest z-layer ends at zlaytop [ ], if not, it ends at the initial water level.
 uniformHeight1D                = 3.0               # Uniform height for 1D profiles and 1d2d internal links [m].


### PR DESCRIPTION
Updated default (-1) was discussed with @arthurvd and the default value in the FM user manual was also updated