### PR TITLE
implemented ability to pass on meshkernel parameters from hydrolib 

### DIFF
--- a/hydrolib/core/dflowfm/net/models.py
+++ b/hydrolib/core/dflowfm/net/models.py
@@ -256,13 +256,13 @@ class Mesh2d(BaseModel):
             interiors = parts[1:]
 
         # Inside
-        else:            
+        else:
             # Get exterior and interiors
             parts = split_by(geometrylist, geometrylist.geometry_separator)
 
             exteriors = parts[:]
             interiors = []
-        
+
         # Delete everything outside the (Multi)Polygon
         for exterior in exteriors:
             self.meshkernel.mesh2d_delete(
@@ -279,22 +279,24 @@ class Mesh2d(BaseModel):
                 invert_deletion=inside,
             )
 
-    def refine(self, 
-               polygon: mk.GeometryList, 
-               level: int, 
-               refine_intersected: bool=False,
-               use_mass_center_when_refining: bool=True,
-               refinement_type: int=2,
-               connect_hanging_nodes: bool=True,
-               account_for_samples_outside_face: bool=False,
-               min_edge_size: float = 0.5):
+    def refine(
+        self,
+        polygon: mk.GeometryList,
+        level: int,
+        refine_intersected: bool = False,
+        use_mass_center_when_refining: bool = True,
+        refinement_type: int = 2,
+        connect_hanging_nodes: bool = True,
+        account_for_samples_outside_face: bool = False,
+        min_edge_size: float = 0.5,
+    ):
         """Refine the mesh within a polygon, by a number of steps (level)
 
         Args:
             polygon (GeometryList): Polygon in which to refine
             level (int): Number of refinement steps
             refine_intersected (bool): whether to compute faces intersected by polygon
-            use_mass_center_when_refining (bool): whether to use the mass center when splitting a face in the refinement process 
+            use_mass_center_when_refining (bool): whether to use the mass center when splitting a face in the refinement process
             min_edge_size (float): smallest allowed cell size
             refinement_type (int): refinement criterion type
             connect_hanging_nodes (bool): whether to connect hanging nodes at the end of the iteration
@@ -1185,23 +1187,26 @@ class Network:
         )
 
     def mesh2d_refine_mesh(
-        self, 
-        polygon: mk.GeometryList, 
-        level: int = None,         
-        refine_intersected: bool=False,
-        use_mass_center_when_refining: bool=True,
-        refinement_type: int=2,
-        connect_hanging_nodes: bool=True,
-        account_for_samples_outside_face: bool=False,
-        min_edge_size: float=0.5):
-        self._mesh2d.refine(polygon=polygon, 
-                            level=level, 
-                            refine_intersected=refine_intersected,
-                            use_mass_center_when_refining=use_mass_center_when_refining,
-                            refinement_type=refinement_type,
-                            connect_hanging_nodes=connect_hanging_nodes,
-                            account_for_samples_outside_face=account_for_samples_outside_face,
-                            min_edge_size=min_edge_size)
+        self,
+        polygon: mk.GeometryList,
+        level: int = None,
+        refine_intersected: bool = False,
+        use_mass_center_when_refining: bool = True,
+        refinement_type: int = 2,
+        connect_hanging_nodes: bool = True,
+        account_for_samples_outside_face: bool = False,
+        min_edge_size: float = 0.5,
+    ):
+        self._mesh2d.refine(
+            polygon=polygon,
+            level=level,
+            refine_intersected=refine_intersected,
+            use_mass_center_when_refining=use_mass_center_when_refining,
+            refinement_type=refinement_type,
+            connect_hanging_nodes=connect_hanging_nodes,
+            account_for_samples_outside_face=account_for_samples_outside_face,
+            min_edge_size=min_edge_size,
+        )
 
     def mesh1d_add_branch(
         self,

--- a/hydrolib/core/dflowfm/net/models.py
+++ b/hydrolib/core/dflowfm/net/models.py
@@ -256,29 +256,13 @@ class Mesh2d(BaseModel):
             interiors = parts[1:]
 
         # Inside
-        else:
-            # Check if any polygon contains holes, when clipping inside
-            if geometrylist.inner_outer_separator in geometrylist.x_coordinates:
-                raise NotImplementedError(
-                    "Deleting inside a (Multi)Polygon with holes is not implemented."
-                )
-
+        else:            
             # Get exterior and interiors
             parts = split_by(geometrylist, geometrylist.geometry_separator)
 
             exteriors = parts[:]
             interiors = []
-
-        # Check if parts are closed
-        for part in exteriors + interiors:
-            if (part.x_coordinates[0], part.y_coordinates[0]) != (
-                part.x_coordinates[-1],
-                part.y_coordinates[-1],
-            ):
-                raise ValueError(
-                    "First and last coordinate of each GeometryList part should match."
-                )
-
+        
         # Delete everything outside the (Multi)Polygon
         for exterior in exteriors:
             self.meshkernel.mesh2d_delete(
@@ -295,28 +279,37 @@ class Mesh2d(BaseModel):
                 invert_deletion=inside,
             )
 
-    def refine(self, polygon: mk.GeometryList, level: int, min_edge_size: float = 10.0):
+    def refine(self, 
+               polygon: mk.GeometryList, 
+               level: int, 
+               refine_intersected: bool=False,
+               use_mass_center_when_refining: bool=True,
+               refinement_type: int=2,
+               connect_hanging_nodes: bool=True,
+               account_for_samples_outside_face: bool=False,
+               min_edge_size: float = 0.5):
         """Refine the mesh within a polygon, by a number of steps (level)
 
         Args:
             polygon (GeometryList): Polygon in which to refine
             level (int): Number of refinement steps
+            refine_intersected (bool): whether to compute faces intersected by polygon
+            use_mass_center_when_refining (bool): whether to use the mass center when splitting a face in the refinement process 
+            min_edge_size (float): smallest allowed cell size
+            refinement_type (int): refinement criterion type
+            connect_hanging_nodes (bool): whether to connect hanging nodes at the end of the iteration
+            account_for_samples_outside_face (bool): whether to take samples outside face into account
+
+            Default values are taken from meskernel documentation.
         """
 
-        # Check if parts are closed
-        # if not (polygon.x_coordinates[0], polygon.y_coordinates[0]) == (
-        #     polygon.x_coordinates[-1],
-        #     polygon.y_coordinates[-1],
-        # ):
-        #     raise ValueError("First and last coordinate of each GeometryList part should match.")
-
         parameters = mk.MeshRefinementParameters(
-            refine_intersected=True,
-            use_mass_center_when_refining=False,
+            refine_intersected=refine_intersected,
+            use_mass_center_when_refining=use_mass_center_when_refining,
             min_edge_size=min_edge_size,
-            refinement_type=1,
-            connect_hanging_nodes=True,
-            account_for_samples_outside_face=False,
+            refinement_type=refinement_type,
+            connect_hanging_nodes=connect_hanging_nodes,
+            account_for_samples_outside_face=account_for_samples_outside_face,
             max_refinement_iterations=level,
         )
         self.meshkernel.mesh2d_refine_based_on_polygon(polygon, parameters)
@@ -1192,9 +1185,23 @@ class Network:
         )
 
     def mesh2d_refine_mesh(
-        self, polygon: mk.GeometryList, level: int = 1, min_edge_size: float = 10.0
-    ) -> None:
-        self._mesh2d.refine(polygon=polygon, level=level, min_edge_size=min_edge_size)
+        self, 
+        polygon: mk.GeometryList, 
+        level: int = None,         
+        refine_intersected: bool=False,
+        use_mass_center_when_refining: bool=True,
+        refinement_type: int=2,
+        connect_hanging_nodes: bool=True,
+        account_for_samples_outside_face: bool=False,
+        min_edge_size: float=0.5):
+        self._mesh2d.refine(polygon=polygon, 
+                            level=level, 
+                            refine_intersected=refine_intersected,
+                            use_mass_center_when_refining=use_mass_center_when_refining,
+                            refinement_type=refinement_type,
+                            connect_hanging_nodes=connect_hanging_nodes,
+                            account_for_samples_outside_face=account_for_samples_outside_face,
+                            min_edge_size=min_edge_size)
 
     def mesh1d_add_branch(
         self,

--- a/tests/dflowfm/test_net.py
+++ b/tests/dflowfm/test_net.py
@@ -275,14 +275,14 @@ def test_create_refine_2d():
 
     mesh2d_output = mesh2d.get_mesh2d()
 
-    assert mesh2d_output.node_x.size == 114
-    assert mesh2d_output.edge_nodes.size == 426
+    assert mesh2d_output.node_x.size == 95
+    assert mesh2d_output.edge_nodes.size == 362
 
     # check fnc
     fnc = mesh2d.mesh2d_face_nodes
-    assert fnc.shape == (100, 4)
+    assert fnc.shape == (87, 4)
     fnc_fill_value = np.iinfo(np.int32).min
-    assert (fnc == fnc_fill_value).sum() == 12  # amount of triangles
+    assert (fnc == fnc_fill_value).sum() == 19  # amount of triangles
 
 
 cases = [


### PR DESCRIPTION
Extended refinement functions to allow passing of meshkernel parameters and removed checks for clipping (functionality they say is not implemented does in fact work).

In the process the default values that were hardcoded in hydrolib core were changed to the same values as are used in meshkernel (they make more sense), hense the asserts in the refinement test failed, as the number of cells changed slightly. They test has been updated.