### PR TITLE
Remove exclude unset option from _save method

### DIFF
--- a/hydrolib/core/basemodel.py
+++ b/hydrolib/core/basemodel.py
@@ -1293,7 +1293,7 @@ class ParsableFileModel(FileModel):
         Args:
             save_settings (ModelSaveSettings): The model save settings.
         """
-        self._serialize(self.dict(exclude_unset=True), save_settings)
+        self._serialize(self.dict(), save_settings)
 
     def _serialize(self, data: dict, save_settings: ModelSaveSettings) -> None:
         """Serializes the data to file. Should not be called directly, only through `_save`.

--- a/hydrolib/core/dflowfm/t3d/models.py
+++ b/hydrolib/core/dflowfm/t3d/models.py
@@ -134,7 +134,7 @@ class T3DModel(ParsableFileModel):
         layers (List[float]):
             List of layers.
         vectormax (Optional[int]):
-            The VECTORMAX value.
+            The VECTORMAX value. Default is None.
         layer_type (LayerType):
             The layer type.
         quantities_names (Optional[List[str]]):
@@ -160,7 +160,7 @@ class T3DModel(ParsableFileModel):
                 T3DTimeRecord(time='0 seconds since 2006-01-01 00:00:00 +00:00', data=[5.0, 5.0, 10.0, 10.0]),
                 T3DTimeRecord(time='1e9 seconds since 2001-01-01 00:00:00 +00:00', data=[5.0, 5.0, 10.0, 10.0])
             ],
-            layers=[1.0, 2.0, 3.0, 4.0, 5.0], vectormax=1, layer_type='SIGMA'
+            layers=[1.0, 2.0, 3.0, 4.0, 5.0], vectormax=None, layer_type='SIGMA', quantities_names=None
         )
         >>> print(model.size)
         (2, 4)

--- a/hydrolib/core/dflowfm/t3d/models.py
+++ b/hydrolib/core/dflowfm/t3d/models.py
@@ -183,7 +183,7 @@ class T3DModel(ParsableFileModel):
     comments: List[str] = Field(default_factory=list)
     records: List[T3DTimeRecord] = Field(default_factory=list)
     layers: List[float] = Field(default_factory=list)
-    vectormax: Optional[int] = Field(default=1, alias="VECTORMAX")
+    vectormax: Optional[int] = Field(default=None, alias="VECTORMAX")
     layer_type: LayerType = Field(default=None, alias="LAYER_TYPE")
     quantities_names: Optional[List[str]] = Field(default=None)
 

--- a/hydrolib/core/dflowfm/tim/models.py
+++ b/hydrolib/core/dflowfm/tim/models.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from pandas import DataFrame
 from pydantic.v1 import Field
@@ -145,7 +145,7 @@ class TimModel(ParsableFileModel):
 
     def __init__(
         self,
-        filepath: Optional[str | Path] = None,
+        filepath: Optional[Union[str, Path]] = None,
         quantities_names: Optional[List[str]] = None,
         **parsable_file_kwargs,
     ):

--- a/hydrolib/tools/extforce_convert/main_converter.py
+++ b/hydrolib/tools/extforce_convert/main_converter.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Optional, Tuple, Union
+
 from tqdm import tqdm
 
 from hydrolib.core.basemodel import PathOrStr

--- a/hydrolib/tools/extforce_convert/main_converter.py
+++ b/hydrolib/tools/extforce_convert/main_converter.py
@@ -1,10 +1,7 @@
 import os
-import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Optional, Tuple, Union
-
-from pydantic.v1.error_wrappers import ValidationError
 from tqdm import tqdm
 
 from hydrolib.core.basemodel import PathOrStr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,11 +118,7 @@ line_length = 88
 
 [tool.pytest.ini_options]
 markers = ["plots", "docker"]
-addopts = """
---ignore=tests/rr/test_fnm.py
---deselect=tests/test_model.py::test_dimr_mode_save
---deselect=tests/test_model.py::test_dimr_model
-"""
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
### Description
The `exclude_unset=True` made some testcases fail. Remove this option and re-enable testcases.
Fixed the failing save model for t3d. 

- Set the default value for VECTORMAX to None see issue #756 
- Removed the `exclude_unset=True` in `ParsableFileModel._save`
- Fixed issue with `TimModel` for str or Path typing by using a `Union[str, Path]`

# Issues
- Fixes #804 