### PR TITLE
Task/812-Refactor the MDU functionalities

### DIFF
--- a/hydrolib/tools/extforce_convert/main_converter.py
+++ b/hydrolib/tools/extforce_convert/main_converter.py
@@ -228,7 +228,7 @@ class ExternalForcingConverter:
                 )
 
         if self.mdu_parser is not None:
-            self._update_fm_model()
+            self._update_mdu_file()
 
         return self.ext_model, self.inifield_model, self.structure_model
 
@@ -453,7 +453,7 @@ class ExternalForcingConverter:
             )
         return structure_file
 
-    def _update_fm_model(self):
+    def _update_mdu_file(self):
         """Update the FM model with the new external forcings, initial fields and structures files.
 
         - The FM model will be saved with a postfix added to the filename.

--- a/hydrolib/tools/extforce_convert/main_converter.py
+++ b/hydrolib/tools/extforce_convert/main_converter.py
@@ -327,9 +327,11 @@ class ExternalForcingConverter:
         if len(self.structure_model.structure) > 0:
             self._save_structure_model(backup, recursive)
 
-        if backup and self.ext_model.filepath.exists():
-            backup_file(self.ext_model.filepath)
-        self.ext_model.save(recurse=recursive)
+        num_quantities_ext = len(self.ext_model.meteo) + len(self.ext_model.sourcesink) + len(self.ext_model.boundary) + len(self.ext_model.lateral)
+        if num_quantities_ext:
+            if backup and self.ext_model.filepath.exists():
+                backup_file(self.ext_model.filepath)
+            self.ext_model.save(recurse=recursive)
 
         if self.mdu_info is not None:
             mdu_file = self.mdu_info.get("file_path")

--- a/hydrolib/tools/extforce_convert/mdu_parser.py
+++ b/hydrolib/tools/extforce_convert/mdu_parser.py
@@ -213,7 +213,7 @@ class MDUParser:
             return
         self.updated_lines.append(f"{stripped}\n")
 
-    def get_temperature_salinity_data(self) -> dict[str, Any]:
+    def get_temperature_salinity_data(self) -> Dict[str, Any]:
         """Get the info needed from the mdu to process and convert the old external forcing files.
 
         Returns:

--- a/hydrolib/tools/extforce_convert/mdu_parser.py
+++ b/hydrolib/tools/extforce_convert/mdu_parser.py
@@ -213,7 +213,7 @@ class MDUParser:
             return
         self.updated_lines.append(f"{stripped}\n")
 
-    def get_temperature_salinity_data(self) -> dict[str, Path | str | bool | Any]:
+    def get_temperature_salinity_data(self) -> dict[str, Any]:
         """Get the info needed from the mdu to process and convert the old external forcing files.
 
         Returns:

--- a/hydrolib/tools/extforce_convert/mdu_parser.py
+++ b/hydrolib/tools/extforce_convert/mdu_parser.py
@@ -1,24 +1,47 @@
-from typing import List
-
+from typing import List, Tuple, Dict
+from datetime import datetime
+from pathlib import Path
+from hydrolib.core.dflowfm.mdu.models import FMModel, Physics, Time
 from hydrolib.core.basemodel import PathOrStr
+from hydrolib.tools.extforce_convert.utils import IgnoreUnknownKeyWordClass
 
 
 class MDUParser:
     """A class to update the ExtForceFileNew entry in an MDU file."""
 
-    def __init__(self, mdu_path: PathOrStr, new_forcing_filename: PathOrStr):
+    def __init__(self, mdu_path: PathOrStr):
         """Initialize the MDUParser.
 
         Args:
             mdu_path: Path to the MDU file to update
-            new_forcing_filename: New filename for the ExtForceFileNew entry
         """
+        mdu_path = Path(mdu_path) if not isinstance(mdu_path, Path) else mdu_path
+        if not mdu_path.exists():
+            raise FileNotFoundError(f"File not found: {mdu_path}")
+
         self.mdu_path = mdu_path
-        self.new_forcing_filename = new_forcing_filename
         self.updated_lines = []
         self.inside_external_forcing = False
         self.found_extforcefilenew = False
         self._content = self._read_file()
+
+    @property
+    def new_forcing_file(self):
+        if not hasattr(self, "_new_forcing_file"):
+            raise AttributeError("new_forcing_file not set")
+        return self._new_forcing_file
+
+    @new_forcing_file.setter
+    def new_forcing_file(self, file_name: PathOrStr):
+        """Set the new filename for the ExtForceFileNew entry.
+
+        Args:
+            file_name(PathOrStr):
+                New filename for the ExtForceFileNew entry
+        """
+        if not isinstance(file_name, PathOrStr):
+            raise ValueError("new_forcing_filename must be a str or Path")
+        self._new_forcing_file = file_name
 
     def _read_file(self) -> List[str]:
         """Read the MDU file into a list of strings.
@@ -89,7 +112,7 @@ class MDUParser:
 
         # If we ended the file while still in [external forcing] with no ExtForceFileNew found, add it
         if self.inside_external_forcing and not self.found_extforcefilenew:
-            new_line = f"ExtForceFileNew                           = {self.new_forcing_filename}\n"
+            new_line = f"ExtForceFileNew                           = {self.new_forcing_file}\n"
             self.updated_lines.append(new_line)
             self.updated_lines.append("\n")
 
@@ -133,13 +156,13 @@ class MDUParser:
         left_part = line[: eq_index + 1]
         # Remainder of the line (after '=')
         right_part = line[eq_index + 1 :].strip("\n")  # noqa: E203
-        name_len = len(self.new_forcing_filename)
+        name_len = len(str(self.new_forcing_file))
         # Protect against filename overflow into the comment
         right_part_clipped = right_part[name_len + 1 :]
         if right_part_clipped.find("#") == -1 and right_part_clipped != "":
             right_part_clipped = f" {right_part.lstrip()}"
         # Insert new filename immediately after '=' + a space
-        return f"{left_part} {self.new_forcing_filename}{right_part_clipped}\n"
+        return f"{left_part} {self.new_forcing_file}{right_part_clipped}\n"
 
     def _handle_external_forcing_section(self, stripped: str) -> None:
         """Handle a line within the [external forcing] section.
@@ -157,7 +180,7 @@ class MDUParser:
         if self.is_section_header(stripped):
             # If we never found ExtForceFileNew before leaving, add it now
             if not self.found_extforcefilenew:
-                new_line = f"ExtForceFileNew                           = {self.new_forcing_filename}\n"
+                new_line = f"ExtForceFileNew                           = {self.new_forcing_file}\n"
                 self.updated_lines.extend([new_line, "\n"])
 
             self.inside_external_forcing = False
@@ -174,6 +197,32 @@ class MDUParser:
             return
         self.updated_lines.append(f"{stripped}\n")
 
+    def get_mdu_info(self) -> Tuple[Dict, Dict]:
+        """Get the info needed from the mdu to process and convert the old external forcing files.
+
+        Returns:
+            data (Dict[str, str]):
+                all the data inside the mdu file, with each section in the file as a key and the data of that section is
+                the value of that key.
+            mdu_info (Dict[str, str]):
+                dictionary with the information needed for the conversion tool to convert the `SourceSink` and
+                `Boundary` quantities. The dictionary will have three keys `temperature`, `salinity`, and `refdate`.
+        """
+        data = FMModel._load(FMModel, self.mdu_path)
+        # read sections of the mdu file.
+        time_data = data.get("time")
+        physics_data = data.get("physics")
+        mdu_time = IgnoreUnknownKeyWordClass(Time, **time_data)
+        mdu_physics = IgnoreUnknownKeyWordClass(Physics, **physics_data)
+
+        ref_time = get_ref_time(mdu_time.refdate)
+        mdu_info = {
+            "file_path": self.mdu_path,
+            "refdate": ref_time,
+            "temperature": False if mdu_physics.temperature == 0 else True,
+            "salinity": mdu_physics.salinity,
+        }
+        return data, mdu_info
 
 def save_mdu_file(content: List[str], output_path: PathOrStr) -> None:
     """Save the updated MDU file content to disk.
@@ -184,3 +233,7 @@ def save_mdu_file(content: List[str], output_path: PathOrStr) -> None:
     """
     with open(output_path, "w", encoding="utf-8") as f:
         f.writelines(content)
+
+def get_ref_time(input_date: str, date_format: str = "%Y%m%d"):
+    date_object = datetime.strptime(f"{input_date}", date_format)
+    return f"MINUTES SINCE {date_object}"

--- a/hydrolib/tools/extforce_convert/mdu_parser.py
+++ b/hydrolib/tools/extforce_convert/mdu_parser.py
@@ -1,3 +1,5 @@
+"""MDU Parser."""
+
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Union
@@ -41,6 +43,7 @@ class MDUParser:
 
     @property
     def new_forcing_file(self) -> Union[Path, str]:
+        """Get the filename for the ExtForceFileNew entry."""
         if not hasattr(self, "_new_forcing_file"):
             raise AttributeError("new_forcing_file not set")
         return self._new_forcing_file
@@ -68,6 +71,7 @@ class MDUParser:
         return lines
 
     def save(self, backup: bool = False) -> None:
+        """Save the updated MDU file."""
         if backup:
             backup_file(self.mdu_path)
 
@@ -93,7 +97,8 @@ class MDUParser:
         self._content = new_content
 
     def update_extforce_file_new(self) -> List[str]:
-        """
+        """Update the ExtForceFileNew entry in the MDU file.
+
         Update the 'ExtForceFileNew' entry under the '[external forcing]' section
         of an MDU file. Writes the updated content to output_path if provided,
         or overwrites the original file otherwise.
@@ -265,5 +270,6 @@ def save_mdu_file(content: List[str], output_path: PathOrStr) -> None:
 
 
 def get_ref_time(input_date: str, date_format: str = "%Y%m%d"):
+    """Convert a date string to a datetime object."""
     date_object = datetime.strptime(f"{input_date}", date_format)
     return f"MINUTES SINCE {date_object}"

--- a/hydrolib/tools/extforce_convert/mdu_parser.py
+++ b/hydrolib/tools/extforce_convert/mdu_parser.py
@@ -41,7 +41,7 @@ class MDUParser:
             file_name(PathOrStr):
                 New filename for the ExtForceFileNew entry
         """
-        if not isinstance(file_name, PathOrStr):
+        if not isinstance(file_name, (Path, str)):
             raise ValueError("new_forcing_filename must be a str or Path")
         self._new_forcing_file = file_name
 

--- a/hydrolib/tools/extforce_convert/mdu_parser.py
+++ b/hydrolib/tools/extforce_convert/mdu_parser.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Any, Union, Dict, List
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -27,13 +28,13 @@ class MDUParser:
         self._content = self._read_file()
 
     @property
-    def new_forcing_file(self):
+    def new_forcing_file(self) -> Union[Path, str]:
         if not hasattr(self, "_new_forcing_file"):
             raise AttributeError("new_forcing_file not set")
         return self._new_forcing_file
 
     @new_forcing_file.setter
-    def new_forcing_file(self, file_name: PathOrStr):
+    def new_forcing_file(self, file_name: Union[Path, str]) -> None:
         """Set the new filename for the ExtForceFileNew entry.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ exclude = '''
 '''
 
 [tool.flake8]
-ignore = ["E501", "W503", "E731"]
+ignore = ["E501", "W503", "E731", "E203"]
 per-file-ignores = [
     '__init__.py:F401',
 ]

--- a/tests/tools/test_converter_boundary_condition.py
+++ b/tests/tools/test_converter_boundary_condition.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 from typing import Dict, List
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 
 import pytest
 
 from hydrolib.core.basemodel import DiskOnlyFileModel
 from hydrolib.core.dflowfm.ext.models import Boundary
 from hydrolib.core.dflowfm.extold.models import ExtOldForcing, ExtOldQuantity
+from hydrolib.tools.extforce_convert.mdu_parser import MDUParser
 from hydrolib.tools.extforce_convert.converters import BoundaryConditionConverter
 from hydrolib.tools.extforce_convert.main_converter import ExternalForcingConverter
 from tests.utils import compare_two_files, is_macos
@@ -291,15 +292,19 @@ class TestMainConverter:
         The old external forcing file contains only 9 boundary condition quantities all with polyline location files
         and no forcing files. The update method should convert all the quantities to boundary conditions.
         """
-        mdu_info = {"refdate": start_date}
+        mock_mdu_parser = MagicMock(spec=MDUParser)
+        mock_mdu_parser.temperature_salinity_data = {"refdate": start_date}
+
+        # mdu_info = {"refdate": start_date}
         converter = ExternalForcingConverter(
-            old_forcing_file_boundary["path"], mdu_info=mdu_info
+            old_forcing_file_boundary["path"], mdu_parser=mock_mdu_parser
         )
 
         # Mock the fm_model
-        mock_fm_model = Mock()
-        converter._fm_model = mock_fm_model
-        ext_model, inifield_model, structure_model = converter.update()
+        # mock_fm_model = Mock()
+        # converter._fm_model = mock_fm_model
+        with patch("hydrolib.tools.extforce_convert.main_converter.ExternalForcingConverter._update_fm_model"):
+            ext_model, inifield_model, structure_model = converter.update()
 
         # all the quantities in the old external file are initial conditions
         # check that all the quantities (3) were converted to initial conditions

--- a/tests/tools/test_converter_boundary_condition.py
+++ b/tests/tools/test_converter_boundary_condition.py
@@ -295,14 +295,10 @@ class TestMainConverter:
         mock_mdu_parser = MagicMock(spec=MDUParser)
         mock_mdu_parser.temperature_salinity_data = {"refdate": start_date}
 
-        # mdu_info = {"refdate": start_date}
         converter = ExternalForcingConverter(
             old_forcing_file_boundary["path"], mdu_parser=mock_mdu_parser
         )
 
-        # Mock the fm_model
-        # mock_fm_model = Mock()
-        # converter._fm_model = mock_fm_model
         with patch(
             "hydrolib.tools.extforce_convert.main_converter.ExternalForcingConverter._update_fm_model"
         ):

--- a/tests/tools/test_converter_boundary_condition.py
+++ b/tests/tools/test_converter_boundary_condition.py
@@ -300,7 +300,7 @@ class TestMainConverter:
         )
 
         with patch(
-            "hydrolib.tools.extforce_convert.main_converter.ExternalForcingConverter._update_fm_model"
+            "hydrolib.tools.extforce_convert.main_converter.ExternalForcingConverter._update_mdu_file"
         ):
             ext_model, inifield_model, structure_model = converter.update()
 

--- a/tests/tools/test_converters_source_sink.py
+++ b/tests/tools/test_converters_source_sink.py
@@ -449,7 +449,7 @@ class TestMainConverter:
         with (
             patch("pathlib.Path.with_suffix", return_value=self.tim_file),
             patch(
-                "hydrolib.tools.extforce_convert.main_converter.ExternalForcingConverter._update_fm_model"
+                "hydrolib.tools.extforce_convert.main_converter.ExternalForcingConverter._update_mdu_file"
             ),
         ):
             ext_model, inifield_model, structure_model = converter.update()
@@ -474,7 +474,7 @@ class TestMainConverter:
         with (
             patch("pathlib.Path.with_suffix", return_value=self.tim_file),
             patch(
-                "hydrolib.tools.extforce_convert.main_converter.ExternalForcingConverter._update_fm_model"
+                "hydrolib.tools.extforce_convert.main_converter.ExternalForcingConverter._update_mdu_file"
             ),
         ):
             ext_model, inifield_model, structure_model = converter.update()

--- a/tests/tools/test_converters_source_sink.py
+++ b/tests/tools/test_converters_source_sink.py
@@ -427,12 +427,12 @@ class TestConverter:
 
 class TestMainConverter:
     path = "tests/data/input/source-sink/source-sink.ext"
-    mdu_info = {
+    temperature_and_salinity_info = {
         "refdate": "minutes since 2015-01-01 00:00:00",
     }
     tim_file = Path("tim-3-columns.tim")
     mdu_parser = MagicMock(spec=MDUParser)
-    mdu_parser.temperature_salinity_data = mdu_info
+    mdu_parser.temperature_salinity_data = temperature_and_salinity_info
 
     def test_sources_sinks_only(self, old_forcing_file_boundary: Dict[str, str]):
         """

--- a/tests/tools/test_converters_source_sink.py
+++ b/tests/tools/test_converters_source_sink.py
@@ -1,11 +1,12 @@
 from pathlib import Path
 from typing import Dict
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 
 import pytest
 
 from hydrolib.core.dflowfm.ext.models import SourceSink
 from hydrolib.core.dflowfm.extold.models import ExtOldForcing, ExtOldQuantity
+from hydrolib.tools.extforce_convert.mdu_parser import MDUParser
 from hydrolib.tools.extforce_convert.converters import SourceSinkConverter
 from hydrolib.tools.extforce_convert.main_converter import ExternalForcingConverter
 
@@ -430,6 +431,8 @@ class TestMainConverter:
         "refdate": "minutes since 2015-01-01 00:00:00",
     }
     tim_file = Path("tim-3-columns.tim")
+    mdu_parser = MagicMock(spec=MDUParser)
+    mdu_parser.temperature_salinity_data = mdu_info
 
     def test_sources_sinks_only(self, old_forcing_file_boundary: Dict[str, str]):
         """
@@ -441,12 +444,17 @@ class TestMainConverter:
         polyline but the `tim-3-columns.tim` is mocked in the test.
 
         """
-        converter = ExternalForcingConverter(self.path, mdu_info=self.mdu_info)
+        # mdu_parser = MagicMock(spec=MDUParser)
+        # mdu_parser.temperature_salinity_data = self.mdu_info
+        converter = ExternalForcingConverter(self.path, mdu_parser=self.mdu_parser)
         # Mock the fm_model
         mock_fm_model = Mock()
         converter._fm_model = mock_fm_model
 
-        with patch("pathlib.Path.with_suffix", return_value=self.tim_file):
+        with (
+            patch("pathlib.Path.with_suffix", return_value=self.tim_file),
+            patch("hydrolib.tools.extforce_convert.main_converter.ExternalForcingConverter._update_fm_model")
+        ):
             ext_model, inifield_model, structure_model = converter.update()
 
         self._compare(ext_model, inifield_model, structure_model)
@@ -461,15 +469,18 @@ class TestMainConverter:
         polyline but the `tim-3-columns.tim` is mocked in the test.
 
         """
-        self.mdu_info["salinity"] = True
-        self.mdu_info["temperature"] = True
+        self.mdu_parser.temperature_salinity_data["salinity"] = True
+        self.mdu_parser.temperature_salinity_data["temperature"] = True
 
-        converter = ExternalForcingConverter(self.path, mdu_info=self.mdu_info)
-        # Mock the fm_model
+        converter = ExternalForcingConverter(self.path, mdu_parser=self.mdu_parser)
+
         mock_fm_model = Mock()
         converter._fm_model = mock_fm_model
 
-        with patch("pathlib.Path.with_suffix", return_value=self.tim_file):
+        with (
+            patch("pathlib.Path.with_suffix", return_value=self.tim_file),
+            patch("hydrolib.tools.extforce_convert.main_converter.ExternalForcingConverter._update_fm_model")
+        ):
             ext_model, inifield_model, structure_model = converter.update()
 
         self._compare(ext_model, inifield_model, structure_model)

--- a/tests/tools/test_converters_source_sink.py
+++ b/tests/tools/test_converters_source_sink.py
@@ -444,12 +444,7 @@ class TestMainConverter:
         polyline but the `tim-3-columns.tim` is mocked in the test.
 
         """
-        # mdu_parser = MagicMock(spec=MDUParser)
-        # mdu_parser.temperature_salinity_data = self.mdu_info
         converter = ExternalForcingConverter(self.path, mdu_parser=self.mdu_parser)
-        # Mock the fm_model
-        mock_fm_model = Mock()
-        converter._fm_model = mock_fm_model
 
         with (
             patch("pathlib.Path.with_suffix", return_value=self.tim_file),
@@ -475,9 +470,6 @@ class TestMainConverter:
         self.mdu_parser.temperature_salinity_data["temperature"] = True
 
         converter = ExternalForcingConverter(self.path, mdu_parser=self.mdu_parser)
-
-        mock_fm_model = Mock()
-        converter._fm_model = mock_fm_model
 
         with (
             patch("pathlib.Path.with_suffix", return_value=self.tim_file),

--- a/tests/tools/test_main_converter.py
+++ b/tests/tools/test_main_converter.py
@@ -169,7 +169,7 @@ class TestExtOldToNewFromMDU:
 
         with (
             patch(
-                "hydrolib.tools.extforce_convert.main_converter.ExternalForcingConverter.get_mdu_info"
+                "hydrolib.tools.extforce_convert.mdu_parser.MDUParser.get_mdu_info"
             ) as mock_get_mdu_info,
             patch(
                 "hydrolib.tools.extforce_convert.main_converter.ExternalForcingConverter._read_old_file"

--- a/tests/tools/test_main_converter.py
+++ b/tests/tools/test_main_converter.py
@@ -169,8 +169,11 @@ class TestExtOldToNewFromMDU:
 
         with (
             patch(
-                "hydrolib.tools.extforce_convert.mdu_parser.MDUParser.get_mdu_info"
+                "hydrolib.tools.extforce_convert.mdu_parser.MDUParser._load_with_fm_model"
             ) as mock_get_mdu_info,
+            patch(
+                "hydrolib.tools.extforce_convert.mdu_parser.MDUParser.get_temperature_salinity_data"
+            ),
             patch(
                 "hydrolib.tools.extforce_convert.main_converter.ExternalForcingConverter._read_old_file"
             ),
@@ -178,7 +181,7 @@ class TestExtOldToNewFromMDU:
                 "hydrolib.tools.extforce_convert.utils.construct_filemodel_new_or_existing"
             ),
         ):
-            mock_get_mdu_info.return_value = (mdu_file_content, {})
+            mock_get_mdu_info.return_value = mdu_file_content
 
             converter = ExternalForcingConverter.from_mdu(
                 mdu_file, input_files[0], input_files[1], input_files[2]

--- a/tests/tools/test_main_converter.py
+++ b/tests/tools/test_main_converter.py
@@ -8,6 +8,7 @@ from hydrolib.core.dflowfm.ext.models import ExtModel
 from hydrolib.core.dflowfm.extold.models import ExtOldModel
 from hydrolib.core.dflowfm.inifield.models import IniFieldModel
 from hydrolib.core.dflowfm.structure.models import StructureModel
+from hydrolib.core.dflowfm.ext.models import Meteo, SourceSink, Lateral, Boundary
 from hydrolib.tools.extforce_convert import main_converter
 from hydrolib.tools.extforce_convert.main_converter import (
     ExternalForcingConverter,
@@ -262,15 +263,16 @@ class TestExternalFocingConverter:
         mock_ext_old_model.filepath = old_forcing_file_initial_condition["path"]
 
         converter = ExternalForcingConverter(mock_ext_old_model)
-        converter.save()
+        converter._ext_model = MagicMock(spec=ExtModel)
+        converter._ext_model.meteo = [MagicMock(spec=Meteo)]
+        converter._ext_model.sourcesink = [MagicMock(spec=SourceSink)]
+        converter._ext_model.lateral = [MagicMock(spec=Lateral)]
+        converter._ext_model.boundary = [MagicMock(spec=Boundary)]
+        converter._ext_model.filepath = Path("any-path.ext")
 
-        assert converter.ext_model.filepath.exists()
-        assert not converter.inifield_model.filepath.exists()
-        assert not converter.structure_model.filepath.exists()
-        try:
-            converter.ext_model.filepath.unlink()
-        except PermissionError:
-            pass
+        converter.save()
+        converter._ext_model.save.assert_called_once()
+
 
     def test_read_old_file(
         self,

--- a/tests/tools/test_mdu_parser.py
+++ b/tests/tools/test_mdu_parser.py
@@ -40,7 +40,8 @@ def test_update_mdu_on_the_fly(
 ):
     mdu_filename = input_files_dir / input_file
     new_mdu_file = mdu_filename.with_stem(f"{mdu_filename.stem}-updated")
-    updater = MDUParser(mdu_filename, ext_file)
+    updater = MDUParser(mdu_filename)
+    updater.new_forcing_file = ext_file
     updated_mdu_file = updater.update_extforce_file_new()
     assert updated_mdu_file[on_line[0]] == "[external forcing]\n"
     assert updated_mdu_file[on_line[1]] == expected_line
@@ -73,8 +74,9 @@ def test_update_mdu_on_the_fly(
 )
 def test_replace_extforcefilenew(line, expected):
     """Test the replace_extforcefilenew method."""
-    with patch("hydrolib.tools.extforce_convert.mdu_parser.MDUParser._read_file"):
-        parser = MDUParser("dummy_path", "new_file.ext")
+    with patch("hydrolib.tools.extforce_convert.mdu_parser.MDUParser._read_file"), patch("pathlib.Path.exists", return_value=True):
+        parser = MDUParser("dummy_path")
+        parser.new_forcing_file = "new_file.ext"
 
     assert parser.replace_extforcefilenew(line) == expected
 

--- a/tests/tools/test_mdu_parser.py
+++ b/tests/tools/test_mdu_parser.py
@@ -76,7 +76,8 @@ def test_replace_extforcefilenew(line, expected):
     """Test the replace_extforcefilenew method."""
     with patch("hydrolib.tools.extforce_convert.mdu_parser.MDUParser._read_file"), patch("pathlib.Path.exists", return_value=True):
         parser = MDUParser("dummy_path")
-        parser.new_forcing_file = "new_file.ext"
+        parser.new_forcing_file = Path("new_file.ext")
+
 
     assert parser.replace_extforcefilenew(line) == expected
 

--- a/tests/tools/test_mdu_parser.py
+++ b/tests/tools/test_mdu_parser.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from typing import Tuple
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -74,9 +74,12 @@ def test_update_mdu_on_the_fly(
 )
 def test_replace_extforcefilenew(line, expected):
     """Test the replace_extforcefilenew method."""
+    # Mock the MDUParser class and its methods
     with (
         patch("hydrolib.tools.extforce_convert.mdu_parser.MDUParser._read_file"),
         patch("pathlib.Path.exists", return_value=True),
+        patch("hydrolib.tools.extforce_convert.mdu_parser.MDUParser._load_with_fm_model", return_value=None),
+        patch("hydrolib.tools.extforce_convert.mdu_parser.MDUParser.get_temperature_salinity_data", return_value=None),
     ):
         parser = MDUParser("dummy_path")
         parser.new_forcing_file = Path("new_file.ext")


### PR DESCRIPTION
# Description
- Move the mdu file functionalities to the `mdu_parser` module.
- Save the `ExtModel` recursively only if it has any quantities, to avoid re-writing the .bc files that are already in the new format and did not need to be read or re-written.
- Remove the functionalities related to the `LegacyFMModel`.

# Issues
- closes #812 