### PR TITLE
898 link1d2d contact type not found

### DIFF
--- a/hydrolib/core/dflowfm/net/reader.py
+++ b/hydrolib/core/dflowfm/net/reader.py
@@ -119,12 +119,13 @@ class UgridReader:
             return
 
         ds = nc.Dataset(self._ncfile_path)  # type: ignore[import]
-
+        mapping = self._explorer.link1d2d_var_name_mapping
+    
         # Read mesh1d
-        link1d2d_contact_type_arr = self._read_nc_attribute(ds["link1d2d_contact_type"])
+        link1d2d_contact_type_arr = self._read_nc_attribute(ds[mapping["link1d2d_contact_type"]])
         assert (link1d2d_contact_type_arr == 3).all()
-
-        link1d2d_arr = self._read_nc_attribute(ds["link1d2d"])
+    
+        link1d2d_arr = self._read_nc_attribute(ds[mapping["link1d2d"]])
         # set contacts on meshkernel, use .copy() to avoid strided arrays
         mesh1d_indices = link1d2d_arr[:, 0].copy()
         mesh2d_indices = link1d2d_arr[:, 1].copy()

--- a/hydrolib/core/dflowfm/net/reader.py
+++ b/hydrolib/core/dflowfm/net/reader.py
@@ -120,11 +120,13 @@ class UgridReader:
 
         ds = nc.Dataset(self._ncfile_path)  # type: ignore[import]
         mapping = self._explorer.link1d2d_var_name_mapping
-    
+
         # Read mesh1d
-        link1d2d_contact_type_arr = self._read_nc_attribute(ds[mapping["link1d2d_contact_type"]])
+        link1d2d_contact_type_arr = self._read_nc_attribute(
+            ds[mapping["link1d2d_contact_type"]]
+        )
         assert (link1d2d_contact_type_arr == 3).all()
-    
+
         link1d2d_arr = self._read_nc_attribute(ds[mapping["link1d2d"]])
         # set contacts on meshkernel, use .copy() to avoid strided arrays
         mesh1d_indices = link1d2d_arr[:, 0].copy()


### PR DESCRIPTION
# Description

- use a mapping for `link1d2d` and `link1d2d_contact_type` instead of hard-coded variable names

- Fixes #898
## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- ran the test code in the issue
- no tests were added yet

# Checklist:
Prepare items below using:
\[ :x: \] (markdown: `[ :x: ]`) for TODO items
\[ :white_check_mark: \] (markdown: `[ :white_check_mark: ]`) for DONE items
\[ N/A \] for items that are not applicable for this PR.


- \[ N/A \] updated version number in setup.py/pyproject.toml/environment.yml.
- \[ N/A \] updated the lock file.
- \[ N/A \] added changes to History.rst.
- \[ N/A \] updated the latest version in README file.
- [ :x: ] I have added tests that prove my fix is effective or that my feature works.
- [ :white_check_mark: ] New and existing unit tests pass locally with my changes.
- \[ N/A \] documentation are updated.
