### PR TITLE
docs(mdu_parser): clarify clean method behavior on repeated keywords

### DIFF
--- a/hydrolib/tools/extforce_convert/mdu_parser.py
+++ b/hydrolib/tools/extforce_convert/mdu_parser.py
@@ -1028,6 +1028,11 @@ class MDUParser:
     def clean(self):
         """
         Remove the deprecated mdu keywords from the file
+
+        Notes:
+            - The `clean` function only removes the first occurrence of the deprecated keywords from the file. if a
+            keyword is repeated in the file, the `clean` function will only remove the first one.
+            not remove the deprecated
         """
         for keyword in DEPRECATED_KEYS:
             ind = self.find_keyword_lines(keyword)


### PR DESCRIPTION
- Updated docstring to specify that the `clean` method only removes the first occurrence of deprecated keywords.

# Description

- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context.
- List any dependencies that are required for this change.


- Fixes # (issue)
## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Please describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:
Prepare items below using:
\[ :x: \] (markdown: `[ :x: ]`) for TODO items
\[ :white_check_mark: \] (markdown: `[ :white_check_mark: ]`) for DONE items
\[ N/A \] for items that are not applicable for this PR.


- [ ] updated version number in setup.py/pyproject.toml/environment.yml.
- [ ] updated the lock file.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
