### PR TITLE
Set averaging values to default None

### DIFF
--- a/hydrolib/core/dflowfm/inifield/models.py
+++ b/hydrolib/core/dflowfm/inifield/models.py
@@ -143,13 +143,11 @@ class AbstractSpatialField(INIBasedModel, ABC):
         alias="interpolationMethod"
     )
     operand: Optional[Operand] = Field(Operand.override.value, alias="operand")
-    averagingtype: Optional[AveragingType] = Field(
-        AveragingType.mean.value, alias="averagingType"
-    )
-    averagingrelsize: Optional[NonNegativeFloat] = Field(1.01, alias="averagingRelSize")
-    averagingnummin: Optional[PositiveInt] = Field(1, alias="averagingNumMin")
+    averagingtype: Optional[AveragingType] = Field(None, alias="averagingType")
+    averagingrelsize: Optional[NonNegativeFloat] = Field(None, alias="averagingRelSize")
+    averagingnummin: Optional[PositiveInt] = Field(None, alias="averagingNumMin")
     averagingpercentile: Optional[NonNegativeFloat] = Field(
-        0, alias="averagingPercentile"
+        None, alias="averagingPercentile"
     )
     extrapolationmethod: Optional[bool] = Field(False, alias="extrapolationMethod")
     locationtype: Optional[LocationType] = Field(

--- a/tests/data/reference/fm/serialize_initialFields.ini
+++ b/tests/data/reference/fm/serialize_initialFields.ini
@@ -1,4 +1,4 @@
-# written by HYDROLIB-core 0.3.0
+# written by HYDROLIB-core 0.9.6
 
 [General]
 fileVersion = 2.00
@@ -10,10 +10,6 @@ dataFile            = iniwaterlevels.asc
 dataFileType        = arcinfo
 interpolationMethod = triangulation
 operand             = O                  # How this data is combined with previous data for the same quantity (if any).
-averagingType       = mean               # Type of averaging, if interpolationMethod=averaging .
-averagingRelSize    = 1.01               # Relative search cell size for averaging.
-averagingNumMin     = 1                  # Minimum number of points in averaging. Must be ≥ 1.
-averagingPercentile = 0                  # Percentile value for which data values to include in averaging. 0.0 means off.
 extrapolationMethod = 0                  # Option for (spatial) extrapolation.
 locationType        = 2d
 
@@ -22,10 +18,6 @@ quantity            = bedlevel
 dataFile            = inibedlevel.ini
 dataFileType        = 1dField
 operand             = O               # How this data is combined with previous data for the same quantity (if any).
-averagingType       = mean            # Type of averaging, if interpolationMethod=averaging .
-averagingRelSize    = 1.01            # Relative search cell size for averaging.
-averagingNumMin     = 1               # Minimum number of points in averaging. Must be ≥ 1.
-averagingPercentile = 0               # Percentile value for which data values to include in averaging. 0.0 means off.
 extrapolationMethod = 0               # Option for (spatial) extrapolation.
 locationType        = all             # Target location of interpolation.
 
@@ -35,10 +27,6 @@ dataFile            = manning.xyz
 dataFileType        = sample
 interpolationMethod = triangulation
 operand             = O                   # How this data is combined with previous data for the same quantity (if any).
-averagingType       = mean                # Type of averaging, if interpolationMethod=averaging .
-averagingRelSize    = 1.01                # Relative search cell size for averaging.
-averagingNumMin     = 1                   # Minimum number of points in averaging. Must be ≥ 1.
-averagingPercentile = 0                   # Percentile value for which data values to include in averaging. 0.0 means off.
 extrapolationMethod = 0                   # Option for (spatial) extrapolation.
 locationType        = all                 # Target location of interpolation.
 
@@ -48,10 +36,6 @@ dataFile            = calibration1.pol
 dataFileType        = polygon
 interpolationMethod = constant
 operand             = *
-averagingType       = mean                # Type of averaging, if interpolationMethod=averaging .
-averagingRelSize    = 1.01                # Relative search cell size for averaging.
-averagingNumMin     = 1                   # Minimum number of points in averaging. Must be ≥ 1.
-averagingPercentile = 0                   # Percentile value for which data values to include in averaging. 0.0 means off.
 extrapolationMethod = 0                   # Option for (spatial) extrapolation.
 locationType        = all                 # Target location of interpolation.
 value               = 0.03

--- a/tests/data/reference/ini/inifield-with-one-initial.ini
+++ b/tests/data/reference/ini/inifield-with-one-initial.ini
@@ -10,10 +10,6 @@ dataFile            = iniwaterlevel.xyz # Name of file containing field data val
 dataFileType        = sample            # Type of dataFile.
 interpolationMethod = triangulation     # Type of (spatial) interpolation.
 operand             = O                 # How this data is combined with previous data for the same quantity (if any).
-averagingType       = mean              # Type of averaging, if interpolationMethod=averaging .
-averagingRelSize    = 1.01              # Relative search cell size for averaging.
-averagingNumMin     = 1                 # Minimum number of points in averaging. Must be ≥ 1.
-averagingPercentile = 0                 # Percentile value for which data values to include in averaging. 0.0 means off.
 extrapolationMethod = 0                 # Option for (spatial) extrapolation.
 locationType        = all               # Target location of interpolation.
 

--- a/tests/dflowfm/test_inifield.py
+++ b/tests/dflowfm/test_inifield.py
@@ -257,12 +257,8 @@ class TestInitialConditions:
         )
         assert initial_conditions.interpolationmethod is None
         assert initial_conditions.operand == "O"
-        assert initial_conditions.averagingtype == "mean"
-        assert np.isclose(initial_conditions.averagingrelsize, 1.01)
-        assert initial_conditions.averagingnummin == 1
         assert initial_conditions.extrapolationmethod is False
         assert initial_conditions.locationtype == "all"
-        assert np.isclose(initial_conditions.averagingpercentile, 0.0)
 
     def test_setting_optional_fields(self):
         initial_conditions = InitialField(


### PR DESCRIPTION
# Description

- The manual says: https://content.oss.deltares.nl/delft3d/D-Flow_FM_User_Manual.pdf that the averaging values have a default value in D-Flow FM. So these values can be set to none to prevent them being added to `interpolationMethod` that isn't `averaging`


- Fixes #943 
## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Please describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:
Prepare items below using:
\[ :x: \] (markdown: `[ :x: ]`) for TODO items
\[ :white_check_mark: \] (markdown: `[ :white_check_mark: ]`) for DONE items
\[ N/A \] for items that are not applicable for this PR.


- [ ] updated version number in setup.py/pyproject.toml/environment.yml.
- [ ] updated the lock file.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
