### PR TITLE
Test/fix warnings from tests

### DIFF
--- a/tests/base/data.py
+++ b/tests/base/data.py
@@ -1,6 +1,10 @@
-from typing import List
+from pathlib import Path
+from typing import Dict, List
+from unittest.mock import MagicMock
 
-from hydrolib.core.base.models import BaseModel
+from hydrolib.core.base.models import BaseModel, ParsableFileModel
+from hydrolib.core.base.parser import DummmyParser
+from hydrolib.core.base.serializer import DummySerializer
 
 
 # Common test model classes to reduce duplication
@@ -54,3 +58,55 @@ class ParentModelWithFunc(BaseModelWithFunc, ParentTestModel):
     """A parent model that includes the test_func method."""
 
     pass
+
+
+# Common test model classes for ParsableFileModel tests
+class ParsableModelBase(ParsableFileModel):
+    """Base class for parsable file model tests with common structure."""
+
+    name: str = "default"
+    value: int = 0
+
+    @classmethod
+    def _filename(cls) -> str:
+        return "test"
+
+    @classmethod
+    def _ext(cls) -> str:
+        return ".test"
+
+
+class ParsableModelWithMocks(ParsableModelBase):
+    """ParsableFileModel test class using MagicMock for serializer and parser."""
+
+    @classmethod
+    def _get_serializer(cls):
+        return MagicMock()
+
+    @classmethod
+    def _get_parser(cls):
+        return MagicMock(return_value={"name": "parsed", "value": 42})
+
+
+class ParsableModelWithDummies(ParsableModelBase):
+    """ParsableFileModel test class using DummySerializer and DummyParser."""
+
+    @classmethod
+    def _get_serializer(cls):
+        return DummySerializer.serialize
+
+    @classmethod
+    def _get_parser(cls):
+        return DummmyParser.parse
+
+
+class SaveModelBase(ParsableModelWithMocks):
+    """Base class for testing save functionality."""
+
+    @property
+    def _resolved_filepath(self):
+        return Path(f"{self.__class__.__name__.lower()}.test")
+
+    def _load(self, filepath: Path) -> Dict:
+        # Override _load to avoid file not found error
+        return {"name": self.__class__.__name__.lower(), "value": 100}

--- a/tests/base/test_base_models.py
+++ b/tests/base/test_base_models.py
@@ -1,13 +1,12 @@
 import unittest
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from hydrolib.core.base.file_manager import FileLoadContext
 from hydrolib.core.base.models import (
     BaseModel,
     DiskOnlyFileModel,
-    ParsableFileModel,
     SerializerConfig,
     _should_execute,
     _should_traverse,
@@ -19,6 +18,8 @@ from tests.base.data import (
     ModelWithLinks,
     ParentModelWithFunc,
     ParentTestModel,
+    ParsableModelWithMocks,
+    SaveModelBase,
     SimpleTestModel,
 )
 
@@ -104,48 +105,12 @@ class TestBaseModel(unittest.TestCase):
         self.assertIsNone(model._get_identifier({"name": "test", "value": 42}))
 
 
-# Common test model classes for ParsableFileModel tests
-class ParsableModelBase(ParsableFileModel):
-    """Base class for parsable file model tests."""
-
-    name: str = "default"
-    value: int = 0
-
-    @classmethod
-    def _filename(cls) -> str:
-        return "test"
-
-    @classmethod
-    def _ext(cls) -> str:
-        return ".test"
-
-    @classmethod
-    def _get_serializer(cls):
-        return MagicMock()
-
-    @classmethod
-    def _get_parser(cls):
-        return MagicMock(return_value={"name": "parsed", "value": 42})
-
-
-class SaveModelBase(ParsableModelBase):
-    """Base class for testing save functionality."""
-
-    @property
-    def _resolved_filepath(self):
-        return Path(f"{self.__class__.__name__.lower()}.test")
-
-    def _load(self, filepath: Path) -> Dict:
-        # Override _load to avoid file not found error
-        return {"name": self.__class__.__name__.lower(), "value": 100}
-
-
 class TestParsableFileModel(unittest.TestCase):
     """Test cases for the ParsableFileModel class."""
 
     def setUp(self):
         """Set up test fixtures."""
-        self.TestParsableModel = ParsableModelBase
+        self.TestParsableModel = ParsableModelWithMocks
 
     def test_load(self):
         """Test _load method."""

--- a/tests/base/test_models_core.py
+++ b/tests/base/test_models_core.py
@@ -8,13 +8,10 @@ from hydrolib.core.base.models import (
     DiskOnlyFileModel,
     ModelSaveSettings,
     ModelTreeTraverser,
-    ParsableFileModel,
     SerializerConfig,
     _should_execute,
     _should_traverse,
 )
-from hydrolib.core.base.parser import DummmyParser
-from hydrolib.core.base.serializer import DummySerializer
 from tests.base.data import (
     BaseModelWithFunc,
     ChildModelWithFunc,
@@ -22,31 +19,9 @@ from tests.base.data import (
     ModelWithLinks,
     ParentModelWithFunc,
     ParentTestModel,
+    ParsableModelWithDummies,
     SimpleTestModel,
 )
-
-
-class ParsableModelBase(ParsableFileModel):
-    """Base class for parsable file model tests."""
-
-    name: str = "default"
-    value: int = 0
-
-    @classmethod
-    def _filename(cls) -> str:
-        return "test"
-
-    @classmethod
-    def _ext(cls) -> str:
-        return ".test"
-
-    @classmethod
-    def _get_serializer(cls):
-        return DummySerializer.serialize
-
-    @classmethod
-    def _get_parser(cls):
-        return DummmyParser.parse
 
 
 class TestBaseModelFunctions(unittest.TestCase):
@@ -248,7 +223,7 @@ class TestParsableFileModel(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.TestParsableModel = ParsableModelBase
+        self.TestParsableModel = ParsableModelWithDummies
 
     def test_get_quantity_unit(self):
         """Test _get_quantity_unit method with different quantity types."""


### PR DESCRIPTION
# Description

This Pull Request renames several classes in test files that are used to trigger tests only (the classes themselves do not contain tests) to fix the pytest warning. As pytest picks up any class that contain the prefix `test`/`Test` and expect it to contain tests.

## Main Changes:
- Renamed multiple classes across test files to remove prefixes like "Test" where not directly linked to test purposes:
    - TestModelWithLinks → ModelWithLinks.
    - TestBaseModelWithFunc → BaseModelWithFunc.
    - TestParsableModelBase → ParsableModelBase.
    - TestSaveModelBase → SaveModelBase.

- Updated references and usages in methods, test cases, and patches to reflect the new class names

# Issues
- Fixes #979 
## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Please describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:
Prepare items below using:
\[ :x: \] (markdown: `[ :x: ]`) for TODO items
\[ :white_check_mark: \] (markdown: `[ :white_check_mark: ]`) for DONE items
\[ N/A \] for items that are not applicable for this PR.


- [ ] updated version number in setup.py/pyproject.toml/environment.yml.
- [ ] updated the lock file.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
