### PR TITLE
fix: avoid utcnow warning in DIMR docs

### DIFF
--- a/hydrolib/core/dimr/models.py
+++ b/hydrolib/core/dimr/models.py
@@ -1,7 +1,7 @@
 """Dimr models."""
 
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated, Callable, Literal,  Type
 
@@ -155,7 +155,7 @@ class Documentation(BaseModel):
 
     fileVersion: str = "1.3"
     createdBy: str = f"hydrolib-core {__version__}"
-    creationDate: datetime = Field(default_factory=datetime.utcnow)
+    creationDate: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class GlobalSettings(BaseModel):

--- a/tests/dimr/test_dimr.py
+++ b/tests/dimr/test_dimr.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+import warnings
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -64,7 +65,11 @@ def test_dimr_validate():
 
 
 def test_initialize_default_dimr_does_not_raise_exception():
-    DIMR()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        dimr = DIMR()
+
+    assert dimr.documentation.creationDate.tzinfo is timezone.utc
 
 
 def test_dimr_model_save(output_files_dir: Path, reference_files_dir: Path):


### PR DESCRIPTION
# Description

- Fixes #1098.
- Replaces `datetime.utcnow` in `Documentation.creationDate` with a timezone-aware UTC factory compatible with Python 3.10+.
- Updates the existing default `DIMR()` test to treat `DeprecationWarning` as an error and assert that the generated timestamp is UTC-aware.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Not run locally.

Local validation was limited to:

- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`

Remote validation so far:

- `SonarCloud`: passed
- `SonarCloud Code Analysis`: passed

Remote GitHub Actions workflows are currently waiting for maintainer approval for this fork PR and have no logs yet:

- `mkdocs-deploy`: https://github.com/Deltares/HYDROLIB-core/actions/runs/26182996212
- `fm_container`: https://github.com/Deltares/HYDROLIB-core/actions/runs/26182992684

No fork-side `push` workflow run is visible for this branch at the moment.

# Checklist:

- [N/A] updated version number in setup.py/pyproject.toml/environment.yml.
- [N/A] updated the lock file.
- [N/A] added changes to History.rst.
- [N/A] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [N/A] documentation are updated.