### PR TITLE
fix: limit meshkernel warning to macOS

### DIFF
--- a/tests/dflowfm/net/test_net.py
+++ b/tests/dflowfm/net/test_net.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -138,22 +139,26 @@ def network_1d_2d_1d2dlinks():
     return network
 
 
-@pytest.mark.plots
-def test_create_1d_2d_1d2d():
-    # TODO: There is a known issue with the meshkernel package that needs to be
-    # investigated. The reference_size values (20 for macOS, 21 for other platforms)
-    # may change depending on the version of meshkernel used. If this test fails,
-    # please check whether a newer version of the meshkernel package has altered the
-    # contact/link generation behaviour and update the expected values accordingly.
-    import warnings
+def warn_about_macos_meshkernel_link_generation_issue():
+    if not is_macos():
+        return
 
     warnings.warn(
-        "Known issue: the meshkernel package may produce different numbers of "
-        "1d2d links depending on the version. Please verify the meshkernel package "
-        "behaviour if this test fails.",
+        "Known macOS issue: meshkernel may generate a different number of 1d2d "
+        "links on macOS, likely on arm64. If this test fails on macOS, please "
+        "verify the meshkernel link-generation behaviour. "
+        "Hydrolib core - GitHub Issue "
+        "https://github.com/Deltares/HYDROLIB-core/issues/635 "
+        "MeshkernelPy - GitHub Issue "
+        "https://github.com/Deltares/MeshKernelPy/issues/164",
         UserWarning,
-        stacklevel=1,
+        stacklevel=2,
     )
+
+
+@pytest.mark.plots
+def test_create_1d_2d_1d2d():
+    warn_about_macos_meshkernel_link_generation_issue()
     if is_macos():
         reference_size = 20
     else:
@@ -205,21 +210,9 @@ def test_create_1d_2d_1d2d_call_link_generation_twice():
     Related issue: https://github.com/Deltares/HYDROLIB-core/issues/546
     """
     # TODO: There is a known issue with the meshkernel package that needs to be
-    # investigated. The reference_size values (20 for macOS, 21 for other platforms)
-    # may change depending on the version of meshkernel used. If this test fails,
-    # please check whether a newer version of the meshkernel package has altered the
-    # contact/link generation behaviour and update the expected values accordingly.
-    import warnings
-
-    warnings.warn(
-        "Known issue: the meshkernel package may produce different numbers of "
-        "1d2d links depending on the version. Please verify the meshkernel package "
-        "behaviour if this test fails. \n"
-        "Hydrolib core - Github Issue https://github.com/Deltares/HYDROLIB-core/issues/635 \n"
-        "MeshkernelPy - Github Issue https://github.com/Deltares/MeshKernelPy/issues/164",
-        UserWarning,
-        stacklevel=1,
-    )
+    # investigated. The reference_size values reflect the macOS-specific
+    # meshkernel link-generation difference tracked in the linked issues.
+    warn_about_macos_meshkernel_link_generation_issue()
 
     network = network_1d_2d_1d2dlinks()
 


### PR DESCRIPTION
# Description

- Limits the meshkernel 1d2d-link warning in `tests/dflowfm/net/test_net.py` to macOS, where the expected link-count difference is handled.
- Updates the warning text to describe the macOS-specific meshkernel link-generation behavior and keeps the related HYDROLIB-core / MeshKernelPy issue links in one shared helper.
- Fixes #1099

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Not run locally.
- Static Git checks:
  - `git diff --check`
  - `git diff --cached --check`
  - `git diff --check HEAD~1..HEAD`
  - `git show --check --stat --oneline HEAD`
- Remote CI:
  - `SonarCloud`: pass
  - `SonarCloud Code Analysis`: pass
  - GitHub Actions currently reports `action_required` for `mkdocs-deploy` and `fm_container`; no logs are available yet.

# Checklist:

- [N/A] updated version number in setup.py/pyproject.toml/environment.yml.
- [N/A] updated the lock file.
- [N/A] added changes to History.rst.
- [N/A] updated the latest version in README file.
- [N/A] I have added tests that prove my fix is effective or that my feature works.
- [N/A] New and existing unit tests pass locally with my changes.
- [N/A] documentation are updated.