### PR TITLE
feat: support stemheightconvention in MDU veg section

### DIFF
--- a/hydrolib/core/dflowfm/mdu/__init__.py
+++ b/hydrolib/core/dflowfm/mdu/__init__.py
@@ -19,6 +19,7 @@ from .models import (
     ProcessFluxIntegration,
     Restart,
     Sediment,
+    StemHeightConvention,
     Time,
     Trachytopes,
     Vegetation,
@@ -52,6 +53,7 @@ __all__ = [
     "ParticlesThreeDType",
     "Particles",
     "VegetationModelNr",
+    "StemHeightConvention",
     "Vegetation",
     "FMModel",
 ]

--- a/hydrolib/core/dflowfm/mdu/models.py
+++ b/hydrolib/core/dflowfm/mdu/models.py
@@ -2,7 +2,7 @@
 
 from enum import IntEnum
 from pathlib import Path
-from typing import Annotated, Any, Literal, Union, Optional, List, Dict
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import (
     BeforeValidator,
@@ -11,6 +11,7 @@ from pydantic import (
     WrapValidator,
     field_validator,
 )
+from strenum import StrEnum
 
 from hydrolib.core.base.file_manager import ResolveRelativeMode
 from hydrolib.core.base.models import (
@@ -26,6 +27,7 @@ from hydrolib.core.dflowfm.friction.models import FrictionModel
 from hydrolib.core.dflowfm.ini.models import INIBasedModel, INIGeneral, INIModel
 from hydrolib.core.dflowfm.ini.serializer import INISerializerConfig
 from hydrolib.core.dflowfm.ini.util import (
+    enum_value_parser,
     split_string_on_delimiter,
     validate_datetime_string,
 )
@@ -2541,6 +2543,17 @@ class VegetationModelNr(IntEnum):
     BaptistDFM = 1
 
 
+class StemHeightConvention(StrEnum):
+    """Enum class containing the valid values for the StemheightConvention attribute."""
+
+    upward_from_bed = "upward_from_bed"
+    downward_from_surface = "downward_from_surface"
+    allowedvaluestext = (
+        "Stem height convention. Possible values: upward_from_bed, "
+        "downward_from_surface."
+    )
+
+
 class Vegetation(INIBasedModel):
     """
     The `[Veg]` section in an MDU file.
@@ -2567,6 +2580,10 @@ class Vegetation(INIBasedModel):
             "Stem height standard deviation fraction, e.g. 0.1 [-].",
             alias="Stemheightstd",
         )
+        stemheightconvention: Optional[str] = Field(
+            StemHeightConvention.allowedvaluestext,
+            alias="StemheightConvention",
+        )
         densvegminbap: Optional[str] = Field(
             "Minimum vegetation density in Baptist formula. Only in 2D. [1/m2].",
             alias="Densvegminbap",
@@ -2583,7 +2600,16 @@ class Vegetation(INIBasedModel):
     cbveg: Optional[float] = Field(0.0, alias="Cbveg")
     rhoveg: Optional[float] = Field(0.0, alias="Rhoveg")
     stemheightstd: Optional[float] = Field(0.0, alias="Stemheightstd")
+    stemheightconvention: Optional[StemHeightConvention] = Field(
+        StemHeightConvention.upward_from_bed,
+        alias="StemheightConvention",
+    )
     densvegminbap: Optional[float] = Field(0.0, alias="Densvegminbap")
+
+    @field_validator("stemheightconvention", mode="before")
+    @classmethod
+    def _validate_stemheightconvention(cls, v: str) -> StemHeightConvention:
+        return enum_value_parser(v, StemHeightConvention)
 
 
 class FMModel(INIModel):

--- a/tests/dflowfm/test_mdu.py
+++ b/tests/dflowfm/test_mdu.py
@@ -8,6 +8,7 @@ from hydrolib.core.base.models import DiskOnlyFileModel
 from hydrolib.core.dflowfm.bc.models import ForcingModel
 from hydrolib.core.dflowfm.ext.models import Boundary
 from hydrolib.core.dflowfm.friction.models import FrictGeneral
+from hydrolib.core.dflowfm.ini.io_models import Property, Section
 from hydrolib.core.dflowfm.mdu.models import (
     Calibration,
     FMModel,
@@ -20,7 +21,9 @@ from hydrolib.core.dflowfm.mdu.models import (
     ProcessFluxIntegration,
     Restart,
     Sediment,
+    StemHeightConvention,
     Time,
+    Vegetation,
     VegetationModelNr,
 )
 from hydrolib.core.dflowfm.net.models import Network
@@ -154,6 +157,25 @@ class TestModels:
         assert fm_model.veg.cbveg == pytest.approx(0.0)
         assert fm_model.veg.rhoveg == pytest.approx(0.0)
         assert fm_model.veg.stemheightstd == pytest.approx(0.0)
+
+    def test_vegetation_accepts_stemheightconvention_keyword(self):
+        section = Section(
+            header="Veg",
+            content=[
+                Property(
+                    key="stemheightconvention",
+                    value="downward_from_surface",
+                )
+            ],
+        )
+
+        vegetation = Vegetation.model_validate(section)
+
+        assert (
+            vegetation.stemheightconvention
+            == StemHeightConvention.downward_from_surface
+        )
+        assert Vegetation().stemheightconvention == StemHeightConvention.upward_from_bed
 
     def test_mdu_with_3d_settings(self):
         input_mdu = (


### PR DESCRIPTION
# Description

Adds support for the `[Veg]` MDU keyword `stemheightconvention` / `StemheightConvention` by modelling it as a `StemHeightConvention` string enum with the D-Flow FM kernel values:

- `upward_from_bed`
- `downward_from_surface`

Also adds a focused regression test that validates a `[Veg]` section containing the lowercase keyword from the issue.

- Fixes #788

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `uv run pytest tests/dflowfm/test_mdu.py -k 'stemheightconvention'` -> `1 passed, 144 deselected`
- [x] `uv run isort --check-only hydrolib/core/dflowfm/mdu/models.py hydrolib/core/dflowfm/mdu/__init__.py tests/dflowfm/test_mdu.py`

Local environment notes:

- `poetry` is not installed in my local environment, so I used `uv sync --dev` and `uv run` for validation.
- Broader `FMModel` / `ResearchFMModel` tests are blocked locally because `meshkernel` cannot load `/opt/homebrew/opt/libomp/lib/libomp.dylib` on this macOS machine. For example, `uv run pytest tests/dflowfm/test_research.py -k 'create_research_fmmodel or can_save_and_load_research_model_from_scratch_without_errors'` fails before reaching this change with that missing native library.
- `uv run black --check hydrolib/core/dflowfm/mdu/models.py hydrolib/core/dflowfm/mdu/__init__.py tests/dflowfm/test_mdu.py` reports that `models.py` and `test_mdu.py` would be reformatted. The same check also fails on a clean `origin/main` worktree with the current resolved Black version, so I avoided applying unrelated formatting churn in this PR.

# Checklist:

- [N/A] updated version number in setup.py/pyproject.toml/environment.yml.
- [N/A] updated the lock file.
- [N/A] added changes to History.rst.
- [N/A] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [N/A] documentation are updated.
