### PR TITLE
fix(converter): update handling of nudgesalinitytemperature

### DIFF
--- a/hydrolib/core/dflowfm/extold/data/old-external-forcing-data.yaml
+++ b/hydrolib/core/dflowfm/extold/data/old-external-forcing-data.yaml
@@ -44,6 +44,7 @@ Meteo:
         HumidityAirTemperatureCloudiness: humidity_airtemperature_cloudiness
         HumidityAirTemperatureCloudinessSolarRadiation: humidity_airtemperature_cloudiness_solarradiation
         LongWaveRadiation: longwaveradiation
+        NudgeSalinityTemperature: nudgesalinitytemperature
         Rainfall: rainfall
         RainfallRate: rainfall_rate
         SolarRadiation: solarradiation
@@ -63,7 +64,6 @@ Meteo:
         WindStressCoefficient: windstresscoefficient
         WindSpeed: wind_speed
         WindFromDirection: wind_from_direction
-        NudgeSalinityTemperature: nudgesalinitytemperature
 
 
 Parameter:

--- a/hydrolib/core/dflowfm/extold/data/old-external-forcing-data.yaml
+++ b/hydrolib/core/dflowfm/extold/data/old-external-forcing-data.yaml
@@ -63,6 +63,7 @@ Meteo:
         WindStressCoefficient: windstresscoefficient
         WindSpeed: wind_speed
         WindFromDirection: wind_from_direction
+        NudgeSalinityTemperature: nudge_salinity_temperature
 
 
 Parameter:
@@ -81,7 +82,6 @@ Parameter:
         InterceptionLayerThickness: interceptionlayerthickness
         InternalTidesFrictionCoefficient: internaltidesfrictioncoefficient
         LinearFrictionCoefficient: linearfrictioncoefficient
-        NudgeSalinityTemperature: nudge_salinity_temperature
         NudgeRate: nudgerate
         NudgeTime: nudgetime
         SeaIceAreaFraction: sea_ice_area_fraction

--- a/hydrolib/core/dflowfm/extold/data/old-external-forcing-data.yaml
+++ b/hydrolib/core/dflowfm/extold/data/old-external-forcing-data.yaml
@@ -63,7 +63,7 @@ Meteo:
         WindStressCoefficient: windstresscoefficient
         WindSpeed: wind_speed
         WindFromDirection: wind_from_direction
-        NudgeSalinityTemperature: nudge_salinity_temperature
+        NudgeSalinityTemperature: nudgesalinitytemperature
 
 
 Parameter:

--- a/hydrolib/tools/extforce_convert/data/data.yaml
+++ b/hydrolib/tools/extforce_convert/data/data.yaml
@@ -32,7 +32,6 @@ external_forcing:
         - erodablelayerthicknessgrainsize3
         - shiptxy
         # will be moved from the initial conditions file to the new forcing file
-        - nudge_salinity_temperature
         - nudgerate
         - nudgetime
         - sea_ice_area_fraction

--- a/tests/tools/test_converter_meteo.py
+++ b/tests/tools/test_converter_meteo.py
@@ -45,5 +45,5 @@ class TestConvertMeteo:
 
         new_quantity_block = converter.convert(forcing)
         assert isinstance(new_quantity_block, Meteo)
-        assert new_quantity_block.quantity == "nudge_salinity_temperature"
+        assert new_quantity_block.quantity == "nudgesalinitytemperature"
         assert new_quantity_block.forcingfiletype == MeteoForcingFileType.netcdf

--- a/tests/tools/test_converter_meteo.py
+++ b/tests/tools/test_converter_meteo.py
@@ -6,7 +6,7 @@ from hydrolib.core.dflowfm.ext.models import (
     MeteoInterpolationMethod,
 )
 from hydrolib.core.dflowfm.extold.models import ExtOldForcing, ExtOldQuantity
-from hydrolib.tools.extforce_convert.converters import MeteoConverter
+from hydrolib.tools.extforce_convert.converters import ConverterFactory, MeteoConverter
 
 
 class TestConvertMeteo:
@@ -29,3 +29,21 @@ class TestConvertMeteo:
             new_quantity_block.interpolationmethod
             == MeteoInterpolationMethod.linearSpaceTime
         )
+
+    def test_nudge_salinity_temperature_uses_meteo_converter(self):
+        """Test that nudge_salinity_temperature is converted to a Meteo block in the ext file."""
+        forcing = ExtOldForcing(
+            quantity=ExtOldQuantity.NudgeSalinityTemperature,
+            filename="nudge_salinity_temperature.nc",
+            filetype=11,
+            method="3",
+            operand="O",
+        )
+
+        converter = ConverterFactory.create_converter(forcing.quantity)
+        assert isinstance(converter, MeteoConverter)
+
+        new_quantity_block = converter.convert(forcing)
+        assert isinstance(new_quantity_block, Meteo)
+        assert new_quantity_block.quantity == "nudge_salinity_temperature"
+        assert new_quantity_block.forcingfiletype == MeteoForcingFileType.netcdf


### PR DESCRIPTION
# Description
Updated the handling of `nudgesalinitytemperature`

Fixes #1125
- removed `nudgesalinitytemperature` from unsupported quantities
- moved it to the `Meteo` quantities

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Wrote test that checks that the quantity uses `MeteoConverter`
- Tested the converted file with the local Delft3D FM kernel

# Checklist:
Prepare items below using:
\[ :x: \] (markdown: `[ :x: ]`) for TODO items
\[ :white_check_mark: \] (markdown: `[ :white_check_mark: ]`) for DONE items
\[ N/A \] for items that are not applicable for this PR.


- [ ] updated version number in setup.py/pyproject.toml/environment.yml.
- [ ] updated the lock file.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
