### PR TITLE
fix(parser): replace file reading with UTF-8/LATIN-1 compatible utility

### DIFF
--- a/hydrolib/core/base/utils.py
+++ b/hydrolib/core/base/utils.py
@@ -42,12 +42,13 @@ def read_text_file(path: Path) -> list[str]:
     Returns:
         List[str]: Lines of the file, with line endings preserved.
     """
-    raw = path.read_bytes()
     try:
-        text = raw.decode("utf-8")
+        with path.open("r", encoding="utf8") as file:
+            lines = file.readlines()
     except UnicodeDecodeError:
-        text = raw.decode("latin-1")
-    return text.splitlines(keepends=True)
+        with path.open("r", encoding="latin-1") as file:
+            lines = file.readlines()
+    return lines
 
 
 def to_key(string: str) -> str:

--- a/hydrolib/core/base/utils.py
+++ b/hydrolib/core/base/utils.py
@@ -49,6 +49,7 @@ def read_text_file(path: Path) -> list[str]:
         text = raw.decode("latin-1")
     return text.splitlines(keepends=True)
 
+
 def to_key(string: str) -> str:
     """Construct a key name from a given field name.
 

--- a/hydrolib/core/base/utils.py
+++ b/hydrolib/core/base/utils.py
@@ -6,7 +6,7 @@ from enum import Enum, auto
 from hashlib import md5
 from operator import eq, ge, gt, le, lt, ne
 from pathlib import Path
-from typing import Annotated, Any, Callable, List, Optional, Union, get_args, get_origin
+from typing import Annotated, Any, Callable, Union, get_args, get_origin
 
 from pydantic import ValidationInfo
 from pydantic.fields import FieldInfo
@@ -19,13 +19,34 @@ SCIENTIFIC_NOTATION_REGEX = re.compile(SCIENTIFIC_NOTATION_PATTERN)
 
 PYTHON_STYLES = r"\1e\3"
 
+
+def read_text_file(path: Path) -> list[str]:
+    """Read a text file as lines, falling back to Latin-1 if not valid UTF-8.
+
+    Many legacy D-Flow FM input files use Latin-1 encoded characters (e.g. the
+    degree symbol °, byte 0xb0) in comments.  Reading as raw bytes and decoding
+    avoids the context-manager re-yield problem that arises when the decode error
+    occurs during iteration rather than on open.
+
+    Args:
+        path (Path): Path to the file to read.
+
+    Returns:
+        List[str]: Lines of the file, with line endings preserved.
+    """
+    raw = path.read_bytes()
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        text = raw.decode("latin-1")
+    return text.splitlines(keepends=True)
 valid_types = (
     float,
     list[float],
-    List[float],
-    Optional[float],
-    Optional[List[float]],
-    Optional[list[float]],
+    list[float],
+    float | None,
+    list[float] | None,
+    list[float] | None,
 )
 
 
@@ -63,7 +84,7 @@ def to_key(string: str) -> str:
     return string.lower().replace(" ", "_").replace("-", "")
 
 
-def to_list(item: Any) -> List[Any]:
+def to_list(item: Any) -> list[Any]:
     """Puts the specified item in a list if it is an instance of `dict`.
 
     Attributes:
@@ -90,7 +111,7 @@ def str_is_empty_or_none(str_field: str) -> bool:
     return str_field is None or not str_field or str_field.isspace()
 
 
-def get_str_len(str_field: Optional[str]) -> int:
+def get_str_len(str_field: str | None) -> int:
     """
     Get string length or 0 if input is None.
 
@@ -103,7 +124,7 @@ def get_str_len(str_field: Optional[str]) -> int:
     return len(str_field) if str_field else 0
 
 
-def get_substring_between(source: str, start: str, end: str) -> Optional[str]:
+def get_substring_between(source: str, start: str, end: str) -> str | None:
     """Finds the substring between two other strings.
 
     Args:
@@ -481,14 +502,14 @@ class FileChecksumCalculator:
     """FileChecksumCalculator calculator used to calculate the checksum of a file."""
 
     @staticmethod
-    def calculate_checksum(filepath: Path) -> Optional[str]:
+    def calculate_checksum(filepath: Path) -> str | None:
         """Calculate the checksum of the file from the given filepath.
 
         Args:
             filepath (Path): The filepath to the file for which the checksum will be calculated.
 
         Returns:
-            [Optional[str]]:
+            [str | None]:
                 The checksum of the file.
                 When the filepath doesn't exist or the filepath isn't a file, None.
         """
@@ -540,7 +561,7 @@ class FortranScientificNotationConverter:
     """Converter for transforming FORTRAN-style scientific notation to Python-compatible format."""
 
     @classmethod
-    def convert(cls, value: Union[str, List[str]]) -> Union[str, List[str]]:
+    def convert(cls, value: Union[str, list[str]]) -> Union[str, list[str]]:
         """Replace FORTRAN-style scientific notation in a value.
 
         Args:

--- a/hydrolib/core/base/utils.py
+++ b/hydrolib/core/base/utils.py
@@ -6,7 +6,7 @@ from enum import Enum, auto
 from hashlib import md5
 from operator import eq, ge, gt, le, lt, ne
 from pathlib import Path
-from typing import Annotated, Any, Callable, Union, get_args, get_origin
+from typing import Annotated, Any, Callable, List, Union, get_args, get_origin
 
 from pydantic import ValidationInfo
 from pydantic.fields import FieldInfo
@@ -19,6 +19,14 @@ SCIENTIFIC_NOTATION_REGEX = re.compile(SCIENTIFIC_NOTATION_PATTERN)
 
 PYTHON_STYLES = r"\1e\3"
 
+valid_types = (
+    float,
+    list[float],
+    List[float],
+    float | None,
+    List[float] | None,
+    list[float] | None,
+)
 
 def read_text_file(path: Path) -> list[str]:
     """Read a text file as lines, falling back to Latin-1 if not valid UTF-8.
@@ -40,15 +48,6 @@ def read_text_file(path: Path) -> list[str]:
     except UnicodeDecodeError:
         text = raw.decode("latin-1")
     return text.splitlines(keepends=True)
-valid_types = (
-    float,
-    list[float],
-    list[float],
-    float | None,
-    list[float] | None,
-    list[float] | None,
-)
-
 
 def to_key(string: str) -> str:
     """Construct a key name from a given field name.

--- a/hydrolib/core/dflowfm/extold/parser.py
+++ b/hydrolib/core/dflowfm/extold/parser.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import Dict, List
 
+from hydrolib.core.base.utils import read_text_file
 from hydrolib.core.dflowfm.extold.common_io import ORDERED_FORCING_FIELDS
 
 
@@ -29,8 +30,7 @@ class Parser:
             "QUANTITY", "FILENAME", "VARNAME", "SOURCEMASK", "FILETYPE", "METHOD", "OPERAND", "VALUE", "FACTOR", "IFRCTYP",
             "AVERAGINGTYPE", "RELATIVESEARCHCELLSIZE", "EXTRAPOLTOL", "PERCENTILEMINMAX", "AREA", "NUMMIN"
         """
-        with filepath.open(encoding="utf8") as file:
-            lines = file.readlines()
+        lines = read_text_file(filepath)
 
         comments, start_data_index = Parser._parse_header(lines)
         forcings = Parser._parse_data(lines, start_data_index)

--- a/hydrolib/core/dflowfm/polyfile/parser.py
+++ b/hydrolib/core/dflowfm/polyfile/parser.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Un
 from pydantic import Field
 
 from hydrolib.core.base.models import BaseModel
+from hydrolib.core.base.utils import read_text_file
 from hydrolib.core.dflowfm.polyfile.models import (
     Description,
     Metadata,
@@ -599,9 +600,8 @@ def read_polyfile(
 
     parser = Parser(filepath, has_z_value=has_z_values, verbose=verbose)
 
-    with filepath.open("r", encoding="utf8") as f:
-        for line in f:
-            parser.feed_line(line)
+    for line in read_text_file(filepath):
+        parser.feed_line(line)
 
     objs = parser.finalize()
 

--- a/hydrolib/core/dflowfm/polyfile/parser.py
+++ b/hydrolib/core/dflowfm/polyfile/parser.py
@@ -600,7 +600,7 @@ def read_polyfile(
 
     parser = Parser(filepath, has_z_value=has_z_values, verbose=verbose)
 
-    for line in read_text_file(filepath):
+    for line in read_text_file(path=filepath):
         parser.feed_line(line)
 
     objs = parser.finalize()

--- a/hydrolib/core/dflowfm/tim/parser.py
+++ b/hydrolib/core/dflowfm/tim/parser.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from hydrolib.core.base.parser import BaseParser
+from hydrolib.core.base.utils import read_text_file
 
 TimData = Dict[str, List[str]]
 
@@ -33,10 +34,9 @@ class TimParser(BaseParser):
             ValueError: If the file contains a comment that is not at the start of the file.
             ValueError: If the data of the timeseries is empty.
         """
-        with filepath.open(encoding="utf8") as file:
-            lines = file.readlines()
-            comments, start_timeseries_index = TimParser._read_header_comments(lines)
-            timeseries = TimParser._read_time_series_data(lines, start_timeseries_index)
+        lines = read_text_file(filepath)
+        comments, start_timeseries_index = TimParser._read_header_comments(lines)
+        timeseries = TimParser._read_time_series_data(lines, start_timeseries_index)
 
         return {"comments": comments, "timeseries": timeseries}
 

--- a/tests/base/test_base_utils.py
+++ b/tests/base/test_base_utils.py
@@ -745,7 +745,7 @@ class TestReadTextFile:
             pytest.param(
                 b"line1\r\nline2\r\n",
                 ["line1\n", "line2\n"],
-                id="crlf_line_endings_preserved",
+                id="crlf_line_endings_normalized",
             ),
             pytest.param(
                 b"",

--- a/tests/base/test_base_utils.py
+++ b/tests/base/test_base_utils.py
@@ -20,6 +20,7 @@ from hydrolib.core.base.utils import (
     get_str_len,
     get_substring_between,
     operator_str,
+    read_text_file,
     str_is_empty_or_none,
     to_key,
     to_list,
@@ -713,3 +714,56 @@ class TestPathToDictionaryConverter:
 
         assert isinstance(result, DiskOnlyFileModel)
         assert result.filepath == Path("test/path/to/file")
+
+
+class TestReadTextFile:
+    """Test cases for the read_text_file utility function."""
+
+    @pytest.mark.parametrize(
+        "raw_bytes, expected_lines",
+        [
+            pytest.param(
+                b"hello\nworld\n",
+                ["hello\n", "world\n"],
+                id="plain_ascii",
+            ),
+            pytest.param(
+                "café\nnaïve\n".encode("utf-8"),
+                ["café\n", "naïve\n"],
+                id="valid_utf8_multibyte",
+            ),
+            pytest.param(
+                b"* temperature in \xb0C\n",
+                ["* temperature in °C\n"],
+                id="latin1_fallback_degree_symbol",
+            ),
+            pytest.param(
+                b"line1\nvalue = 1.5 \xb0C\nline3\n",
+                ["line1\n", "value = 1.5 °C\n", "line3\n"],
+                id="latin1_fallback_multiple_lines",
+            ),
+            pytest.param(
+                b"line1\r\nline2\r\n",
+                ["line1\r\n", "line2\r\n"],
+                id="crlf_line_endings_preserved",
+            ),
+            pytest.param(
+                b"",
+                [],
+                id="empty_file",
+            ),
+            pytest.param(
+                b"line1\nline2",
+                ["line1\n", "line2"],
+                id="no_trailing_newline",
+            ),
+        ],
+    )
+    def test_read_text_file(self, tmp_path, raw_bytes, expected_lines):
+        f = tmp_path / "test.txt"
+        f.write_bytes(raw_bytes)
+        lines = read_text_file(f)
+        assert isinstance(lines, list)
+        assert all(isinstance(line, str) for line in lines)
+        assert lines == expected_lines
+

--- a/tests/base/test_base_utils.py
+++ b/tests/base/test_base_utils.py
@@ -744,7 +744,7 @@ class TestReadTextFile:
             ),
             pytest.param(
                 b"line1\r\nline2\r\n",
-                ["line1\r\n", "line2\r\n"],
+                ["line1\n", "line2\n"],
                 id="crlf_line_endings_preserved",
             ),
             pytest.param(


### PR DESCRIPTION
# Superseded completly by #999 pr and issue #1021

Added a fallback for files to be decoded using `latin-1` in case `utf-8` fails.


- Fixes #975

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Added tests to check the new utils function and trigger if their decoding performs as expected regardless of characters

# Checklist:
Prepare items below using:
\[ :x: \] (markdown: `[ :x: ]`) for TODO items
\[ :white_check_mark: \] (markdown: `[ :white_check_mark: ]`) for DONE items
\[ N/A \] for items that are not applicable for this PR.


- [ ] updated version number in setup.py/pyproject.toml/environment.yml.
- [ ] updated the lock file.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
