### PR TITLE
Fix/1009 extforce convert initialverticaltemperatureprofile and salinity should not require and write field value and operand

### DIFF
--- a/hydrolib/core/dflowfm/inifield/models.py
+++ b/hydrolib/core/dflowfm/inifield/models.py
@@ -170,7 +170,7 @@ class AbstractSpatialField(INIBasedModel, ABC):
     locationtype: Optional[LocationType] = Field(
         LocationType.all.value, alias="locationType"
     )
-    value: Optional[float] = Field(None, alias="value")
+    value: Optional[float| None] = Field(None, alias="value")
 
     model_config = ConfigDict(extra="allow")
 
@@ -218,12 +218,13 @@ class AbstractSpatialField(INIBasedModel, ABC):
             data_file = DiskOnlyFileModel(data_file)
             values["datafile"] = data_file
 
-        validate_required_fields(
-            values,
-            "value",
-            conditional_field_name="datafiletype",
-            conditional_value=DataFileType.polygon,
-        )
+        if values.get("interpolationmethod") == InterpolationMethod.constant:
+            validate_required_fields(
+                values,
+                "value",
+                conditional_field_name="datafiletype",
+                conditional_value=DataFileType.polygon,
+            )
 
         value_field_value = values.get("value")
         datafiletype_field_value = values.get("datafiletype")

--- a/hydrolib/core/dflowfm/inifield/models.py
+++ b/hydrolib/core/dflowfm/inifield/models.py
@@ -218,7 +218,8 @@ class AbstractSpatialField(INIBasedModel, ABC):
             data_file = DiskOnlyFileModel(data_file)
             values["datafile"] = data_file
 
-        if values.get("interpolationmethod") != InterpolationMethod.constant:
+        if (values.get("interpolationmethod") == InterpolationMethod.constant and
+                not values["quantity"].startswith("initialvertical")):
             validate_required_fields(
                 values,
                 "value",

--- a/hydrolib/core/dflowfm/inifield/models.py
+++ b/hydrolib/core/dflowfm/inifield/models.py
@@ -218,7 +218,7 @@ class AbstractSpatialField(INIBasedModel, ABC):
             data_file = DiskOnlyFileModel(data_file)
             values["datafile"] = data_file
 
-        if values.get("interpolationmethod") == InterpolationMethod.constant:
+        if values.get("interpolationmethod") != InterpolationMethod.constant:
             validate_required_fields(
                 values,
                 "value",

--- a/hydrolib/core/dflowfm/inifield/models.py
+++ b/hydrolib/core/dflowfm/inifield/models.py
@@ -170,7 +170,7 @@ class AbstractSpatialField(INIBasedModel, ABC):
     locationtype: Optional[LocationType] = Field(
         LocationType.all.value, alias="locationType"
     )
-    value: Optional[float| None] = Field(None, alias="value")
+    value: Optional[float] = Field(None, alias="value")
 
     model_config = ConfigDict(extra="allow")
 

--- a/hydrolib/tools/extforce_convert/mdu_parser.py
+++ b/hydrolib/tools/extforce_convert/mdu_parser.py
@@ -1101,7 +1101,7 @@ class MDUParser:
     def get_inifield_file(
         self,
         inifield_file: Optional[PathOrStr],
-    ) -> Path:
+    ) -> Path | None:
         ini_field_file = self.get_keyword(INIFIELD_FILE_LINE)
         root_dir = self.mdu_path.parent
         if inifield_file is not None:
@@ -1123,7 +1123,7 @@ class MDUParser:
     def get_structure_file(
         self,
         usr_structure_file: Optional[PathOrStr],
-    ) -> Path:
+    ) -> Path | None:
         structure_file = self.get_keyword(STRUCTURE_FILE_LINE)
         root_dir = self.mdu_path.parent
 

--- a/hydrolib/tools/extforce_convert/mdu_parser.py
+++ b/hydrolib/tools/extforce_convert/mdu_parser.py
@@ -1100,25 +1100,24 @@ class MDUParser:
 
     def get_inifield_file(
         self,
-        inifield_file: Optional[PathOrStr],
+        user_inifield_file: PathOrStr | None,
     ) -> Path | None:
         ini_field_file = self.get_keyword(INIFIELD_FILE_LINE)
         root_dir = self.mdu_path.parent
-        if inifield_file is not None:
-            # user defined initial field file
-            inifield_file = root_dir / inifield_file
-        elif isinstance(ini_field_file, Path):
-            # from the LegacyFMModel
-            inifield_file = ini_field_file.resolve()
-        elif isinstance(ini_field_file, str) and ini_field_file:
-            # from reading the geometry section (only if non-empty)
-            inifield_file = root_dir / ini_field_file
+
+        # if given by the user use that, otherwise use the one in the mdu file
+        path = user_inifield_file if user_inifield_file is not None else ini_field_file
+
+        if path:
+            path = (root_dir / Path(path)).resolve()
         else:
             print(
                 f"The initial field file is not found in the mdu file, and not provided by the user. \n "
-                f"given: {inifield_file}."
+                f"given: {path}."
             )
-        return inifield_file
+            path = None
+
+        return path
 
     def get_structure_file(
         self,
@@ -1127,21 +1126,19 @@ class MDUParser:
         structure_file = self.get_keyword(STRUCTURE_FILE_LINE)
         root_dir = self.mdu_path.parent
 
-        if usr_structure_file is not None:
-            # user defined structure file
-            usr_structure_file = root_dir / usr_structure_file
-        elif isinstance(structure_file, Path):
-            # from the LegacyFMModel
-            usr_structure_file = structure_file.resolve()
-        elif isinstance(structure_file, str) and structure_file:
-            # from reading the geometry section (only if non-empty)
-            usr_structure_file = root_dir / structure_file
+        # if given by the user use that, otherwise use the one in the mdu file
+        path = usr_structure_file if usr_structure_file is not None else structure_file
+
+        if path:
+            path = (root_dir / Path(path)).resolve()
         else:
             print(
-                "The structure file is not found in the mdu file, and not provide by the user. \n"
-                f"given: {usr_structure_file}."
+                "The structure file is not found in the mdu file, and not provided by the user. \n"
+                f"given: {path}."
             )
-        return usr_structure_file
+            path = None
+
+        return path
 
 
 def save_mdu_file(content: List[str], output_path: PathOrStr) -> None:

--- a/hydrolib/tools/extforce_convert/mdu_parser.py
+++ b/hydrolib/tools/extforce_convert/mdu_parser.py
@@ -1110,8 +1110,8 @@ class MDUParser:
         elif isinstance(ini_field_file, Path):
             # from the LegacyFMModel
             inifield_file = ini_field_file.resolve()
-        elif isinstance(ini_field_file, str):
-            # from reading the geometry section
+        elif isinstance(ini_field_file, str) and ini_field_file:
+            # from reading the geometry section (only if non-empty)
             inifield_file = root_dir / ini_field_file
         else:
             print(
@@ -1125,16 +1125,17 @@ class MDUParser:
         usr_structure_file: Optional[PathOrStr],
     ) -> Path:
         structure_file = self.get_keyword(STRUCTURE_FILE_LINE)
+        root_dir = self.mdu_path.parent
 
         if usr_structure_file is not None:
             # user defined structure file
-            usr_structure_file = self.mdu_path / usr_structure_file
+            usr_structure_file = root_dir / usr_structure_file
         elif isinstance(structure_file, Path):
             # from the LegacyFMModel
             usr_structure_file = structure_file.resolve()
-        elif isinstance(structure_file, str):
-            # from reading the geometry section
-            usr_structure_file = self.mdu_path / structure_file
+        elif isinstance(structure_file, str) and structure_file:
+            # from reading the geometry section (only if non-empty)
+            usr_structure_file = root_dir / structure_file
         else:
             print(
                 "The structure file is not found in the mdu file, and not provide by the user. \n"

--- a/hydrolib/tools/extforce_convert/utils.py
+++ b/hydrolib/tools/extforce_convert/utils.py
@@ -132,10 +132,7 @@ def oldfiletype_to_forcing_file_type(
         raise NotImplementedError(
             "FILETYPE = 8 (magnitude+direction timeseries on stations) is no longer supported."
         )
-    elif oldfiletype == ExtOldFileType.Polyline:  # 9
-        # Boundary polyline files no longer need a filetype of their own (intentionally no error raised)
-        pass
-    elif oldfiletype == ExtOldFileType.InsidePolygon:  # 10
+    elif oldfiletype in [ExtOldFileType.Polyline,  ExtOldFileType.InsidePolygon]:  # 9 and # 10
         forcing_file_type = DataFileType.polygon
     elif oldfiletype == ExtOldFileType.NetCDFGridData:  # 11
         forcing_file_type = MeteoForcingFileType.netcdf

--- a/hydrolib/tools/extforce_convert/utils.py
+++ b/hydrolib/tools/extforce_convert/utils.py
@@ -301,6 +301,9 @@ def create_initial_cond_and_parameter_input_dict(
         "datafiletype": oldfiletype_to_forcing_file_type(forcing.filetype),
     }
 
+    if block_data["datafiletype"] == "polygon":
+        block_data["value"] = forcing.value
+
     if forcing.sourcemask != DiskOnlyFileModel(None):
         raise ValueError(
             f"Attribute 'SOURCEMASK' is no longer supported, cannot "

--- a/hydrolib/tools/extforce_convert/utils.py
+++ b/hydrolib/tools/extforce_convert/utils.py
@@ -303,7 +303,10 @@ def create_initial_cond_and_parameter_input_dict(
         "datafile": DiskOnlyFileModel(new_forcing_path),
         "datafiletype": oldfiletype_to_forcing_file_type(forcing.filetype),
     }
-    if block_data["datafiletype"] == "polygon":
+    block_data = convert_interpolation_data(forcing, block_data)
+
+    if (block_data["datafiletype"] == "polygon" and
+            block_data["interpolationmethod"] == InterpolationMethod.constant):
         block_data["value"] = forcing.value
 
     if forcing.sourcemask != DiskOnlyFileModel(None):
@@ -312,7 +315,6 @@ def create_initial_cond_and_parameter_input_dict(
             f"convert this input. Encountered for QUANTITY="
             f"{forcing.quantity} and FILENAME={forcing.filename}."
         )
-    block_data = convert_interpolation_data(forcing, block_data)
     block_data["operand"] = forcing.operand
 
     if hasattr(forcing, "extrapolation"):

--- a/hydrolib/tools/extforce_convert/utils.py
+++ b/hydrolib/tools/extforce_convert/utils.py
@@ -317,6 +317,14 @@ def create_initial_cond_and_parameter_input_dict(
             f"{forcing.quantity} and FILENAME={forcing.filename}."
         )
     block_data = convert_interpolation_data(forcing, block_data)
+
+    # UNST-9218 / GitHub #1104: initialvertical* quantities must always use
+    # interpolationMethod = constant.  The old METHOD value (typically 3 →
+    # linearSpaceTime) is meaningless for vertical profiles; the kernel always
+    # applies constant (horizontal) + linear (vertical) interpolation internally.
+    if quantity_name.startswith("initialvertical"):
+        block_data["interpolationmethod"] = InterpolationMethod.constant
+
     block_data["operand"] = forcing.operand
 
     if hasattr(forcing, "extrapolation"):

--- a/hydrolib/tools/extforce_convert/utils.py
+++ b/hydrolib/tools/extforce_convert/utils.py
@@ -300,12 +300,6 @@ def create_initial_cond_and_parameter_input_dict(
         "datafile": DiskOnlyFileModel(new_forcing_path),
         "datafiletype": oldfiletype_to_forcing_file_type(forcing.filetype),
     }
-    block_data = convert_interpolation_data(forcing, block_data)
-
-    if (block_data["datafiletype"] == "polygon" and
-            block_data["interpolationmethod"] == InterpolationMethod.constant):
-        if forcing.value is not None:
-            block_data["value"] = forcing.value
 
     if forcing.sourcemask != DiskOnlyFileModel(None):
         raise ValueError(
@@ -313,6 +307,7 @@ def create_initial_cond_and_parameter_input_dict(
             f"convert this input. Encountered for QUANTITY="
             f"{forcing.quantity} and FILENAME={forcing.filename}."
         )
+    block_data = convert_interpolation_data(forcing, block_data)
     block_data["operand"] = forcing.operand
 
     if hasattr(forcing, "extrapolation"):

--- a/hydrolib/tools/extforce_convert/utils.py
+++ b/hydrolib/tools/extforce_convert/utils.py
@@ -307,7 +307,8 @@ def create_initial_cond_and_parameter_input_dict(
 
     if (block_data["datafiletype"] == "polygon" and
             block_data["interpolationmethod"] == InterpolationMethod.constant):
-        block_data["value"] = forcing.value
+        if forcing.value is not None:
+            block_data["value"] = forcing.value
 
     if forcing.sourcemask != DiskOnlyFileModel(None):
         raise ValueError(

--- a/tests/dflowfm/test_inifield.py
+++ b/tests/dflowfm/test_inifield.py
@@ -369,7 +369,7 @@ class TestInitialVerticalProfilePolygonValidation:
     @pytest.mark.unit
     def test_non_initialvertical_polygon_without_value_still_raises(self):
         """Non-initialvertical quantities still require a value when datafiletype=polygon and interpolation=constant."""
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ValidationError, match="value should be provided when datafiletype is polygon"):
             InitialField(
                 quantity="initialwaterlevel",
                 datafile=DiskOnlyFileModel(),
@@ -377,10 +377,6 @@ class TestInitialVerticalProfilePolygonValidation:
                 interpolationmethod=InterpolationMethod.constant,
                 operand=Operand.override,
             )
-
-        assert "value should be provided when datafiletype is polygon" in str(
-            exc_info.value
-        )
 
     @pytest.mark.unit
     def test_initialvertical_polygon_with_value_is_also_valid(self):

--- a/tests/dflowfm/test_inifield.py
+++ b/tests/dflowfm/test_inifield.py
@@ -359,7 +359,7 @@ class TestInitialVerticalProfilePolygonValidation:
             datafile=DiskOnlyFileModel(),
             datafiletype=DataFileType.polygon,
             interpolationmethod=InterpolationMethod.constant,
-            operand="O",
+            operand=Operand.override,
         )
 
         assert model.quantity == quantity
@@ -375,7 +375,7 @@ class TestInitialVerticalProfilePolygonValidation:
                 datafile=DiskOnlyFileModel(),
                 datafiletype=DataFileType.polygon,
                 interpolationmethod=InterpolationMethod.constant,
-                operand="O",
+                operand=Operand.override,
             )
 
         assert "value should be provided when datafiletype is polygon" in str(
@@ -391,7 +391,7 @@ class TestInitialVerticalProfilePolygonValidation:
             datafiletype=DataFileType.polygon,
             interpolationmethod=InterpolationMethod.constant,
             value=0.0,
-            operand="O",
+            operand=Operand.override,
         )
 
         assert np.isclose(model.value, 0.0)

--- a/tests/dflowfm/test_inifield.py
+++ b/tests/dflowfm/test_inifield.py
@@ -272,18 +272,20 @@ class TestInitialConditions:
         assert np.isclose(initial_conditions.averagingpercentile, 95.0)
 
     def test_invalid_datafiletype(self):
+        datafile = DiskOnlyFileModel()
         with pytest.raises(ValueError):
             InitialField(
                 quantity="waterlevel",
-                datafile=DiskOnlyFileModel(),
+                datafile=datafile,
                 datafiletype="invalidType",
             )
 
     def test_invalid_interpolationmethod(self):
+        datafile = DiskOnlyFileModel()
         with pytest.raises(ValueError):
             InitialField(
                 quantity="waterlevel",
-                datafile=DiskOnlyFileModel(),
+                datafile=datafile,
                 datafiletype=DataFileType.arcinfo,
                 interpolationmethod="invalidMethod",
             )
@@ -423,10 +425,11 @@ class TestInitialVerticalProfilePolygonValidation:
     @pytest.mark.unit
     def test_non_initialvertical_polygon_without_value_raises_for_constant(self):
         """Non-initialvertical + polygon + constant interpolation + no value must raise."""
+        datafile = DiskOnlyFileModel()
         with pytest.raises(ValidationError, match="value should be provided when datafiletype is polygon"):
             InitialField(
                 quantity="initialwaterlevel",
-                datafile=DiskOnlyFileModel(),
+                datafile=datafile,
                 datafiletype=DataFileType.polygon,
                 interpolationmethod=InterpolationMethod.constant,
                 operand=Operand.override,

--- a/tests/dflowfm/test_inifield.py
+++ b/tests/dflowfm/test_inifield.py
@@ -68,6 +68,7 @@ class TestIniField:
             quantity="waterlevel",
             datafile="iniwlev.xyz",
             datafiletype="sample",
+            interpolationmethod="constant"
         )
 
         return inifield_values

--- a/tests/dflowfm/test_inifield.py
+++ b/tests/dflowfm/test_inifield.py
@@ -329,3 +329,69 @@ class TestExcludeFromValidation:
 
         model = InitialField(**data)
         assert model.tracerdecaytime == 8640000
+
+
+class TestInitialVerticalProfilePolygonValidation:
+    """Tests for the relaxed polygon/value validation for initialvertical* quantities.
+
+    The validate_that_value_is_present_for_polygons validator skips the 'value required'
+    check for quantities whose name starts with 'initialvertical', because these quantities
+    use polygon datafiletype without a uniform fill value.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "quantity",
+        [
+            pytest.param("initialverticalsalinityprofile", id="salinity"),
+            pytest.param("initialverticaltemperatureprofile", id="temperature"),
+            pytest.param("initialverticalsedfracprofile", id="sedfrac"),
+        ],
+    )
+    def test_initialvertical_polygon_without_value_is_valid(self, quantity):
+        """InitialField with an initialvertical* quantity, polygon datafiletype and no value must be valid.
+
+        This is the key model-level fix: without it, the constant interpolation + polygon
+        validation raises 'value should be provided when datafiletype is polygon'.
+        """
+        model = InitialField(
+            quantity=quantity,
+            datafile=DiskOnlyFileModel(),
+            datafiletype=DataFileType.polygon,
+            interpolationmethod=InterpolationMethod.constant,
+            operand="O",
+        )
+
+        assert model.quantity == quantity
+        assert model.datafiletype == DataFileType.polygon
+        assert model.value is None
+
+    @pytest.mark.unit
+    def test_non_initialvertical_polygon_without_value_still_raises(self):
+        """Non-initialvertical quantities still require a value when datafiletype=polygon and interpolation=constant."""
+        with pytest.raises(ValidationError) as exc_info:
+            InitialField(
+                quantity="initialwaterlevel",
+                datafile=DiskOnlyFileModel(),
+                datafiletype=DataFileType.polygon,
+                interpolationmethod=InterpolationMethod.constant,
+                operand="O",
+            )
+
+        assert "value should be provided when datafiletype is polygon" in str(
+            exc_info.value
+        )
+
+    @pytest.mark.unit
+    def test_initialvertical_polygon_with_value_is_also_valid(self):
+        """Providing a value for an initialvertical* polygon quantity is still allowed."""
+        model = InitialField(
+            quantity="initialverticalsalinityprofile",
+            datafile=DiskOnlyFileModel(),
+            datafiletype=DataFileType.polygon,
+            interpolationmethod=InterpolationMethod.constant,
+            value=0.0,
+            operand="O",
+        )
+
+        assert np.isclose(model.value, 0.0)

--- a/tests/dflowfm/test_inifield.py
+++ b/tests/dflowfm/test_inifield.py
@@ -337,19 +337,31 @@ class TestInitialVerticalProfilePolygonValidation:
     The validate_that_value_is_present_for_polygons validator skips the 'value required'
     check for quantities whose name starts with 'initialvertical', because these quantities
     use polygon datafiletype without a uniform fill value.
+
+    The validation only ever fires when interpolationmethod == constant; for all other
+    methods (triangulation, averaging, linearSpaceTime, None) the check is bypassed
+    regardless of quantity name.
     """
 
+    _vertical_quantities = [
+        pytest.param("initialverticalsalinityprofile", id="salinity"),
+        pytest.param("initialverticaltemperatureprofile", id="temperature"),
+        pytest.param("initialverticalsedfracprofile", id="sedfrac"),
+    ]
+
+    _non_constant_methods = [
+        pytest.param(InterpolationMethod.triangulation, id="triangulation"),
+        pytest.param(InterpolationMethod.averaging, id="averaging"),
+        pytest.param(InterpolationMethod.linear_space_time, id="linearSpaceTime"),
+        pytest.param(None, id="none"),
+    ]
+
     @pytest.mark.unit
-    @pytest.mark.parametrize(
-        "quantity",
-        [
-            pytest.param("initialverticalsalinityprofile", id="salinity"),
-            pytest.param("initialverticaltemperatureprofile", id="temperature"),
-            pytest.param("initialverticalsedfracprofile", id="sedfrac"),
-        ],
-    )
-    def test_initialvertical_polygon_without_value_is_valid(self, quantity):
-        """InitialField with an initialvertical* quantity, polygon datafiletype and no value must be valid.
+    @pytest.mark.parametrize("quantity", _vertical_quantities)
+    def test_initialvertical_polygon_without_value_is_valid_for_constant_interpolation(
+            self, quantity
+    ):
+        """initialvertical* + polygon + constant interpolation + no value must be valid.
 
         This is the key model-level fix: without it, the constant interpolation + polygon
         validation raises 'value should be provided when datafiletype is polygon'.
@@ -367,8 +379,50 @@ class TestInitialVerticalProfilePolygonValidation:
         assert model.value is None
 
     @pytest.mark.unit
-    def test_non_initialvertical_polygon_without_value_still_raises(self):
-        """Non-initialvertical quantities still require a value when datafiletype=polygon and interpolation=constant."""
+    @pytest.mark.parametrize("quantity", _vertical_quantities)
+    @pytest.mark.parametrize("interpolationmethod", _non_constant_methods)
+    def test_initialvertical_polygon_without_value_is_valid_for_non_constant_interpolation_methods(
+        self, quantity, interpolationmethod
+    ):
+        """initialvertical* + polygon + non-constant interpolation + no value must be valid.
+
+        The 'value required' check is only guarded by interpolationmethod == constant,
+        so all other methods must allow polygon without a value for any quantity name.
+        """
+        model = InitialField(
+            quantity=quantity,
+            datafile=DiskOnlyFileModel(),
+            datafiletype=DataFileType.polygon,
+            interpolationmethod=interpolationmethod,
+            operand=Operand.override,
+        )
+
+        assert model.quantity == quantity
+        assert model.value is None
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("interpolationmethod", _non_constant_methods)
+    def test_non_initialvertical_polygon_without_value_is_valid_for_non_constant_methods(
+        self, interpolationmethod
+    ):
+        """Non-initialvertical + polygon + non-constant interpolation + no value must be valid.
+
+        The validation only fires for constant interpolation, so other methods never
+        require a value even for regular quantities.
+        """
+        model = InitialField(
+            quantity="initialwaterlevel",
+            datafile=DiskOnlyFileModel(),
+            datafiletype=DataFileType.polygon,
+            interpolationmethod=interpolationmethod,
+            operand=Operand.override,
+        )
+
+        assert model.value is None
+
+    @pytest.mark.unit
+    def test_non_initialvertical_polygon_without_value_raises_for_constant(self):
+        """Non-initialvertical + polygon + constant interpolation + no value must raise."""
         with pytest.raises(ValidationError, match="value should be provided when datafiletype is polygon"):
             InitialField(
                 quantity="initialwaterlevel",
@@ -379,15 +433,25 @@ class TestInitialVerticalProfilePolygonValidation:
             )
 
     @pytest.mark.unit
-    def test_initialvertical_polygon_with_value_is_also_valid(self):
-        """Providing a value for an initialvertical* polygon quantity is still allowed."""
+    @pytest.mark.parametrize("quantity", _vertical_quantities)
+    @pytest.mark.parametrize(
+        "interpolationmethod",
+        [
+            pytest.param(InterpolationMethod.constant, id="constant"),
+            *_non_constant_methods,
+        ],
+    )
+    def test_initialvertical_polygon_with_value_is_valid_for_all_methods(
+        self, quantity, interpolationmethod
+    ):
+        """Providing a value for any initialvertical* polygon quantity is always allowed."""
         model = InitialField(
-            quantity="initialverticalsalinityprofile",
+            quantity=quantity,
             datafile=DiskOnlyFileModel(),
             datafiletype=DataFileType.polygon,
-            interpolationmethod=InterpolationMethod.constant,
-            value=0.0,
+            interpolationmethod=interpolationmethod,
+            value=12.34,
             operand=Operand.override,
         )
 
-        assert np.isclose(model.value, 0.0)
+        assert np.isclose(model.value, 12.34)

--- a/tests/tools/mdu_parser/test_mdu_parser_methods.py
+++ b/tests/tools/mdu_parser/test_mdu_parser_methods.py
@@ -220,3 +220,127 @@ class TestMDUParserIsRelativeToParent:
 
         result = MDUParser.is_relative_to_parent.fget(parser)
         assert result is False
+
+
+class TestMDUParserGetIniFieldFile:
+    """Unit tests for MDUParser.get_inifield_file method.
+
+    Tests the path resolution logic for the IniFieldFile entry, including the fix
+    that prevents an empty string value from being joined with the root directory
+    (which would produce a directory path and cause a PermissionError on save).
+    """
+
+    def _make_parser(self, content: list) -> MagicMock:
+        parser = MagicMock(spec=MDUParser)
+        parser.get_inifield_file = MethodType(MDUParser.get_inifield_file, parser)
+        parser.get_keyword = MethodType(MDUParser.get_keyword, parser)
+        parser.find_keyword_lines = MethodType(MDUParser.find_keyword_lines, parser)
+        parser.content = content
+        return parser
+
+    @pytest.mark.unit
+    def test_get_inifield_file_when_user_provides_path(self, tmp_path):
+        """When the caller supplies a path it is joined with mdu_path.parent."""
+        parser = self._make_parser(["[geometry]\n", "IniFieldFile = existing.ini\n"])
+        parser.mdu_path = tmp_path / "run" / "model.mdu"
+
+        result = MDUParser.get_inifield_file(parser, "user.ini")
+
+        assert result == tmp_path / "run" / "user.ini"
+
+    @pytest.mark.unit
+    def test_get_inifield_file_when_mdu_has_non_empty_value(self, tmp_path):
+        """A non-empty IniFieldFile value in the MDU is resolved relative to mdu_path.parent."""
+        parser = self._make_parser(["[geometry]\n", "IniFieldFile = fields.ini\n"])
+        parser.mdu_path = tmp_path / "run" / "model.mdu"
+
+        result = MDUParser.get_inifield_file(parser, None)
+
+        assert result == tmp_path / "run" / "fields.ini"
+
+    @pytest.mark.unit
+    def test_get_inifield_file_when_mdu_has_empty_value_returns_none(self, tmp_path):
+        """Regression test: IniFieldFile = (empty) must NOT produce a directory path.
+
+        Before the fix, an empty string was passed to root_dir / "", yielding the
+        directory itself. On save this caused PermissionError: [Errno 13] Permission
+        denied: '<directory>'.
+        """
+        parser = self._make_parser(["[geometry]\n", "IniFieldFile = \n"])
+        parser.mdu_path = tmp_path / "run" / "model.mdu"
+
+        result = MDUParser.get_inifield_file(parser, None)
+
+        # The method falls through to the else branch and returns None (no path built)
+        assert result is None
+
+    @pytest.mark.unit
+    def test_get_inifield_file_when_mdu_has_no_entry_returns_none(self, tmp_path):
+        """When IniFieldFile is absent entirely the result is None."""
+        parser = self._make_parser(["[geometry]\n"])
+        parser.mdu_path = tmp_path / "run" / "model.mdu"
+
+        result = MDUParser.get_inifield_file(parser, None)
+
+        assert result is None
+
+
+class TestMDUParserGetStructureFile:
+    """Unit tests for MDUParser.get_structure_file method.
+
+    Tests path resolution for the StructureFile entry including:
+    - The fix that prevents empty strings from being joined with the root directory.
+    - The fix that uses mdu_path.parent (not mdu_path) when building the path.
+    """
+
+    def _make_parser(self, content: list) -> MagicMock:
+        parser = MagicMock(spec=MDUParser)
+        parser.get_structure_file = MethodType(MDUParser.get_structure_file, parser)
+        parser.get_keyword = MethodType(MDUParser.get_keyword, parser)
+        parser.find_keyword_lines = MethodType(MDUParser.find_keyword_lines, parser)
+        parser.content = content
+        return parser
+
+    @pytest.mark.unit
+    def test_get_structure_file_when_user_provides_path(self, tmp_path):
+        """When the caller supplies a path it is joined with mdu_path.parent (not mdu_path).
+
+        Before the fix, self.mdu_path / usr_structure_file was used, which appended the
+        filename to the .mdu file itself rather than its parent directory.
+        """
+        parser = self._make_parser(["[geometry]\n", "StructureFile = existing.ini\n"])
+        parser.mdu_path = tmp_path / "run" / "model.mdu"
+
+        result = MDUParser.get_structure_file(parser, "user-structures.ini")
+
+        assert result == tmp_path / "run" / "user-structures.ini"
+
+    @pytest.mark.unit
+    def test_get_structure_file_when_mdu_has_non_empty_value(self, tmp_path):
+        """A non-empty StructureFile value in the MDU is resolved relative to mdu_path.parent."""
+        parser = self._make_parser(["[geometry]\n", "StructureFile = structures.ini\n"])
+        parser.mdu_path = tmp_path / "run" / "model.mdu"
+
+        result = MDUParser.get_structure_file(parser, None)
+
+        assert result == tmp_path / "run" / "structures.ini"
+
+    @pytest.mark.unit
+    def test_get_structure_file_when_mdu_has_empty_value_returns_none(self, tmp_path):
+        """Regression test: StructureFile = (empty) must NOT produce a directory path."""
+        parser = self._make_parser(["[geometry]\n", "StructureFile = \n"])
+        parser.mdu_path = tmp_path / "run" / "model.mdu"
+
+        result = MDUParser.get_structure_file(parser, None)
+
+        assert result is None
+
+    @pytest.mark.unit
+    def test_get_structure_file_when_mdu_has_no_entry_returns_none(self, tmp_path):
+        """When StructureFile is absent entirely the result is None."""
+        parser = self._make_parser(["[geometry]\n"])
+        parser.mdu_path = tmp_path / "run" / "model.mdu"
+
+        result = MDUParser.get_structure_file(parser, None)
+
+        assert result is None

--- a/tests/tools/test_converter_inifields.py
+++ b/tests/tools/test_converter_inifields.py
@@ -388,3 +388,58 @@ class TestOldFiletypeToForcingFileType:
         assert oldfiletype_to_forcing_file_type(
             ExtOldFileType.Polyline
         ) == oldfiletype_to_forcing_file_type(ExtOldFileType.InsidePolygon)
+
+
+class TestInitialVerticalInterpolationMethodOverride:
+    """Tests for UNST-9218 / GitHub #1104: initialvertical* must use constant interpolation.
+
+    The old external forcings file typically uses METHOD=3 (linearSpaceTime) for
+    initialvertical* quantities. The converter must override this to 'constant',
+    because the kernel always uses constant (horizontal) interpolation for vertical
+    profiles — linearSpaceTime is invalid for these quantities.
+    """
+
+    _vertical_quantities = [
+        "initialverticalsalinityprofile",
+        "initialverticaltemperatureprofile",
+        "initialverticalsedfracprofileSand",
+    ]
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("quantity", _vertical_quantities)
+    @pytest.mark.parametrize("method", [1, 2, 3, 4, 5])
+    def test_initialvertical_forces_constant_interpolation(self, quantity, method, tmp_path):
+        """Any old METHOD value must be overridden to 'constant' for initialvertical* quantities."""
+        forcing_file = tmp_path / "profile.pli"
+        forcing_file.write_text("dummy")
+
+        forcing = ExtOldForcing(
+            quantity=quantity,
+            filename=DiskOnlyFileModel(filepath=forcing_file),
+            filetype=ExtOldFileType.Polyline,
+            method=method,
+            operand="O",
+        )
+
+        result = create_initial_cond_and_parameter_input_dict(forcing, forcing_file)
+
+        assert result["interpolationmethod"] == InterpolationMethod.constant
+
+    @pytest.mark.unit
+    def test_non_vertical_quantity_preserves_original_method(self, tmp_path):
+        """Non-initialvertical quantities must keep the converted interpolation method."""
+        forcing_file = tmp_path / "data.xyz"
+        forcing_file.write_text("dummy")
+
+        forcing = ExtOldForcing(
+            quantity=ExtOldQuantity("initialwaterlevel"),
+            filename=DiskOnlyFileModel(filepath=forcing_file),
+            filetype=ExtOldFileType.Samples,
+            method=5,
+            operand="O",
+        )
+
+        result = create_initial_cond_and_parameter_input_dict(forcing, forcing_file)
+
+        assert result["interpolationmethod"] == InterpolationMethod.triangulation
+

--- a/tests/tools/test_converter_inifields.py
+++ b/tests/tools/test_converter_inifields.py
@@ -32,7 +32,7 @@ class TestConvertInitialCondition:
             quantity=ExtOldQuantity.InitialWaterLevel,
             filename="iniwaterlevel.xyz",
             filetype=7,  # "Polyline"
-            method="5",  # "Interpolate space",
+            method="5",  # "Interpolate space"
             operand="O",
         )
 
@@ -142,7 +142,7 @@ class TestConvertParameters:
             quantity=ExtOldQuantity.FrictionCoefficient,
             filename="iniwaterlevel.xyz",
             filetype=7,  # "Polyline"
-            method="5",  # "Interpolate space",
+            method="5",  # "Interpolate space"
             operand="O",
         )
 

--- a/tests/tools/test_converter_inifields.py
+++ b/tests/tools/test_converter_inifields.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from hydrolib.core.base.models import DiskOnlyFileModel
-from hydrolib.core.dflowfm.extold.models import ExtOldForcing, ExtOldQuantity
+from hydrolib.core.dflowfm.extold.models import ExtOldFileType, ExtOldForcing, ExtOldQuantity
 from hydrolib.core.dflowfm.inifield.models import (
     DataFileType,
     IniFieldModel,
@@ -13,7 +13,6 @@ from hydrolib.core.dflowfm.inifield.models import (
     InterpolationMethod,
     ParameterField,
 )
-from hydrolib.core.dflowfm.extold.models import ExtOldFileType
 from hydrolib.tools.extforce_convert.converters import (
     ConverterFactory,
     InitialConditionConverter,
@@ -313,82 +312,3 @@ class TestOldFiletypeToForcingFileType:
         assert oldfiletype_to_forcing_file_type(
             ExtOldFileType.Polyline
         ) == oldfiletype_to_forcing_file_type(ExtOldFileType.InsidePolygon)
-
-
-class TestVerticalProfileConversion:
-    """Tests for conversion of initial vertical profile quantities using FILETYPE=9.
-
-    These are regression tests for the PermissionError / InitialFieldError that occurred
-    when running extforce-convert on MDU files with initialverticalsalinityprofile entries.
-    """
-
-    @pytest.mark.unit
-    @pytest.mark.parametrize(
-        "quantity",
-        [
-            pytest.param(
-                ExtOldQuantity.InitialVerticalSalinityProfile,
-                id="salinity",
-            ),
-            pytest.param(
-                ExtOldQuantity.InitialVerticalTemperatureProfile,
-                id="temperature",
-            ),
-        ],
-    )
-    def test_vertical_profile_filetype9_produces_polygon_datafiletype(self, quantity):
-        """FILETYPE=9 with a vertical profile quantity must result in datafiletype=polygon.
-
-        This ensures the dict passed to InitialField uses a valid DataFileType value
-        and does not contain the invalid 'unknown' string.
-        """
-        forcing = ExtOldForcing(
-            quantity=quantity,
-            filename="inisal.pli",
-            filetype=9,
-            method="1",
-            operand="O",
-        )
-
-        data = create_initial_cond_and_parameter_input_dict(
-            forcing, forcing.filename.filepath
-        )
-
-        assert data["datafiletype"] == DataFileType.polygon
-
-    @pytest.mark.unit
-    @pytest.mark.parametrize(
-        "quantity",
-        [
-            pytest.param(
-                ExtOldQuantity.InitialVerticalSalinityProfile,
-                id="salinity",
-            ),
-            pytest.param(
-                ExtOldQuantity.InitialVerticalTemperatureProfile,
-                id="temperature",
-            ),
-        ],
-    )
-    def test_vertical_profile_filetype9_creates_initial_field_without_error(
-        self, quantity
-    ):
-        """Converting a vertical profile quantity with FILETYPE=9 must not raise.
-
-        This is the primary regression test for the bug reported in issue anticreep01:
-        hydrolib.core.dflowfm.ext.models.InitialFieldError: Failed to create the
-        InitialField object. ... Invalid enum value: 'unknown'
-        """
-        forcing = ExtOldForcing(
-            quantity=quantity,
-            filename="inisal.pli",
-            filetype=9,
-            method="1",
-            operand="O",
-        )
-
-        block = InitialConditionConverter().convert(forcing, forcing.filename.filepath)
-
-        assert isinstance(block, InitialField)
-        assert block.datafiletype == DataFileType.polygon
-

--- a/tests/tools/test_converter_inifields.py
+++ b/tests/tools/test_converter_inifields.py
@@ -13,6 +13,7 @@ from hydrolib.core.dflowfm.inifield.models import (
     InterpolationMethod,
     ParameterField,
 )
+from hydrolib.core.dflowfm.extold.models import ExtOldFileType
 from hydrolib.tools.extforce_convert.converters import (
     ConverterFactory,
     InitialConditionConverter,
@@ -21,6 +22,7 @@ from hydrolib.tools.extforce_convert.converters import (
 from hydrolib.tools.extforce_convert.main_converter import ExternalForcingConverter
 from hydrolib.tools.extforce_convert.utils import (
     create_initial_cond_and_parameter_input_dict,
+    oldfiletype_to_forcing_file_type,
 )
 from tests.utils import compare_two_files, ignore_version_lines
 
@@ -284,3 +286,109 @@ class TestInifieldConverter:
         )
         assert diff == []
         path.unlink()
+
+
+class TestOldFiletypeToForcingFileType:
+    """Tests for oldfiletype_to_forcing_file_type — especially the FILETYPE=9 change."""
+
+    @pytest.mark.unit
+    def test_filetype_9_polyline_maps_to_polygon(self):
+        """Regression test: FILETYPE=9 (Polyline) must now map to DataFileType.polygon.
+
+        Before the fix, FILETYPE=9 fell through without setting a value, returning the
+        default "unknown", which caused InitialField validation errors downstream.
+        """
+        result = oldfiletype_to_forcing_file_type(ExtOldFileType.Polyline)
+        assert result == DataFileType.polygon
+
+    @pytest.mark.unit
+    def test_filetype_10_inside_polygon_maps_to_polygon(self):
+        """FILETYPE=10 (InsidePolygon) still maps to DataFileType.polygon (unchanged)."""
+        result = oldfiletype_to_forcing_file_type(ExtOldFileType.InsidePolygon)
+        assert result == DataFileType.polygon
+
+    @pytest.mark.unit
+    def test_filetype_9_and_10_return_same_value(self):
+        """FILETYPE=9 and FILETYPE=10 must now return the same datafiletype."""
+        assert oldfiletype_to_forcing_file_type(
+            ExtOldFileType.Polyline
+        ) == oldfiletype_to_forcing_file_type(ExtOldFileType.InsidePolygon)
+
+
+class TestVerticalProfileConversion:
+    """Tests for conversion of initial vertical profile quantities using FILETYPE=9.
+
+    These are regression tests for the PermissionError / InitialFieldError that occurred
+    when running extforce-convert on MDU files with initialverticalsalinityprofile entries.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "quantity",
+        [
+            pytest.param(
+                ExtOldQuantity.InitialVerticalSalinityProfile,
+                id="salinity",
+            ),
+            pytest.param(
+                ExtOldQuantity.InitialVerticalTemperatureProfile,
+                id="temperature",
+            ),
+        ],
+    )
+    def test_vertical_profile_filetype9_produces_polygon_datafiletype(self, quantity):
+        """FILETYPE=9 with a vertical profile quantity must result in datafiletype=polygon.
+
+        This ensures the dict passed to InitialField uses a valid DataFileType value
+        and does not contain the invalid 'unknown' string.
+        """
+        forcing = ExtOldForcing(
+            quantity=quantity,
+            filename="inisal.pli",
+            filetype=9,
+            method="1",
+            operand="O",
+        )
+
+        data = create_initial_cond_and_parameter_input_dict(
+            forcing, forcing.filename.filepath
+        )
+
+        assert data["datafiletype"] == DataFileType.polygon
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "quantity",
+        [
+            pytest.param(
+                ExtOldQuantity.InitialVerticalSalinityProfile,
+                id="salinity",
+            ),
+            pytest.param(
+                ExtOldQuantity.InitialVerticalTemperatureProfile,
+                id="temperature",
+            ),
+        ],
+    )
+    def test_vertical_profile_filetype9_creates_initial_field_without_error(
+        self, quantity
+    ):
+        """Converting a vertical profile quantity with FILETYPE=9 must not raise.
+
+        This is the primary regression test for the bug reported in issue anticreep01:
+        hydrolib.core.dflowfm.ext.models.InitialFieldError: Failed to create the
+        InitialField object. ... Invalid enum value: 'unknown'
+        """
+        forcing = ExtOldForcing(
+            quantity=quantity,
+            filename="inisal.pli",
+            filetype=9,
+            method="1",
+            operand="O",
+        )
+
+        block = InitialConditionConverter().convert(forcing, forcing.filename.filepath)
+
+        assert isinstance(block, InitialField)
+        assert block.datafiletype == DataFileType.polygon
+

--- a/tests/tools/test_main_converter.py
+++ b/tests/tools/test_main_converter.py
@@ -55,13 +55,13 @@ class TestExtOldToNewFromMDU:
         # rename back the backup file
         mdu_filename.with_suffix(".mdu.bak").rename(mdu_filename)
 
-    def test_extrapolate_slr(self, capsys, input_files_dir: Path):
+    def test_extrapolate_slr(self, capsys, monkeypatch, input_files_dir: Path):
         """
         - This test used mdu file with `Unknown keywords` so the reading of the mdu file using the `LegacyFMModel`
         fails.
         - Since the `LegacyFMModel` class is not created, the converter will read only the [physics] and [time] section
         """
-        main_converter._verbose = True
+        monkeypatch.setattr(main_converter, "_verbose", True, raising=False)
         mdu_filename = (
             input_files_dir
             / "e02/f006_external_forcing/c011_extrapolate_slr/slrextrapol.mdu"
@@ -82,8 +82,8 @@ class TestExtOldToNewFromMDU:
         # rename back the backup file
         mdu_filename.with_suffix(".mdu.bak").rename(mdu_filename)
 
-    def test_recursive(self, capsys, input_files_dir: Path):
-        main_converter._verbose = True
+    def test_recursive(self, capsys, monkeypatch, input_files_dir: Path):
+        monkeypatch.setattr(main_converter, "_verbose", True, raising=False)
         path = input_files_dir / "e02/f006_external_forcing"
         with patch(
             "hydrolib.tools.extforce_convert.main_converter.ExternalForcingConverter.save",

--- a/tests/tools/test_main_converter.py
+++ b/tests/tools/test_main_converter.py
@@ -55,13 +55,13 @@ class TestExtOldToNewFromMDU:
         # rename back the backup file
         mdu_filename.with_suffix(".mdu.bak").rename(mdu_filename)
 
-    def test_extrapolate_slr(self, capsys, monkeypatch, input_files_dir: Path):
+    def test_extrapolate_slr(self, capsys, input_files_dir: Path):
         """
         - This test used mdu file with `Unknown keywords` so the reading of the mdu file using the `LegacyFMModel`
         fails.
         - Since the `LegacyFMModel` class is not created, the converter will read only the [physics] and [time] section
         """
-        monkeypatch.setattr(main_converter, "_verbose", True, raising=False)
+        main_converter._verbose = True
         mdu_filename = (
             input_files_dir
             / "e02/f006_external_forcing/c011_extrapolate_slr/slrextrapol.mdu"
@@ -82,8 +82,8 @@ class TestExtOldToNewFromMDU:
         # rename back the backup file
         mdu_filename.with_suffix(".mdu.bak").rename(mdu_filename)
 
-    def test_recursive(self, capsys, monkeypatch, input_files_dir: Path):
-        monkeypatch.setattr(main_converter, "_verbose", True, raising=False)
+    def test_recursive(self, capsys, input_files_dir: Path):
+        main_converter._verbose = True
         path = input_files_dir / "e02/f006_external_forcing"
         with patch(
             "hydrolib.tools.extforce_convert.main_converter.ExternalForcingConverter.save",


### PR DESCRIPTION
# Description

- Added a fix on the MDU parser in case there is no structure or ini file (as found when running the `p:\dflowfm\users\veenstra\extforce-convert\initialvertical\` model
- enhanced the validator to quantity not require a `value` on the quantity if the name starts with "initialvertical***profile" and `interpolationmethod` is constant (see Arthur's comment below)
- assigned the old file type of `polyline` to map to `polygon` (discussed with Julien in a Teams message)


- Fixes #1104 
- Fixes #1009 
- Fixes #787

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- added tests to fix the use-cases when there `initialvertical*` quantities with or without values
- added tests to verify that a `Polyline` (filetype=9) is now correctly assigned a `polygon` type
- added tests to check the fix for parsing of `ini` and `structure` files in the mdu parser

# Checklist:
Prepare items below using:
\[ :x: \] (markdown: `[ :x: ]`) for TODO items
\[ :white_check_mark: \] (markdown: `[ :white_check_mark: ]`) for DONE items
\[ N/A \] for items that are not applicable for this PR.


- [ ] updated version number in setup.py/pyproject.toml/environment.yml.
- [ ] updated the lock file.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
