### PR TITLE
Fix/forcing model error in new ext file

### DIFF
--- a/hydrolib/core/dflowfm/bc/models.py
+++ b/hydrolib/core/dflowfm/bc/models.py
@@ -1227,7 +1227,9 @@ class RealTime(StrEnum):
     """str: Realtime data source, externally provided"""
 
 
-def _reject_disk_only_on_recursive_load(v):
+def _reject_disk_only_on_recursive_load(
+    v: float| RealTime | ForcingModel | DiskOnlyFileModel,
+) -> float| RealTime | ForcingModel | DiskOnlyFileModel:
     """Reject DiskOnlyFileModel when the load context has recurse=True.
 
     This guard ensures that a ``DiskOnlyFileModel`` can only appear as a

--- a/hydrolib/core/dflowfm/bc/models.py
+++ b/hydrolib/core/dflowfm/bc/models.py
@@ -27,6 +27,7 @@ from typing import (
 )
 
 from pydantic import (
+    AfterValidator,
     BeforeValidator,
     ConfigDict,
     Field,
@@ -39,6 +40,7 @@ from pydantic_core import core_schema
 from strenum import StrEnum
 
 from hydrolib.core.base import DiskOnlyFileModel
+from hydrolib.core.base.file_manager import file_load_context
 from hydrolib.core.base.models import BaseModel, ModelSaveSettings
 from hydrolib.core.base.utils import to_list
 from hydrolib.core.dflowfm.ini.io_models import Property, Section
@@ -1225,9 +1227,50 @@ class RealTime(StrEnum):
     """str: Realtime data source, externally provided"""
 
 
-ForcingData = Union[float, RealTime, ForcingModel, DiskOnlyFileModel]
-"""Data type that selects from three different types of forcing data:
+def _reject_disk_only_on_recursive_load(v):
+    """Reject DiskOnlyFileModel when the load context has recurse=True.
+
+    This guard ensures that a ``DiskOnlyFileModel`` can only appear as a
+    ``ForcingData`` value when the model tree is loaded with ``recurse=False``.
+    Under a recursive load the .bc file should be fully parsed into a
+    ``ForcingModel``; if a ``DiskOnlyFileModel`` slips through it indicates a
+    bug in the resolution pipeline.
+    """
+    if isinstance(v, DiskOnlyFileModel):
+
+        with file_load_context() as context:
+            if (
+                hasattr(context, "_load_settings")
+                and context._load_settings is not None
+                and context._load_settings.recurse
+            ):
+                raise ValueError(
+                    "A DiskOnlyFileModel is not valid for ForcingData when loading "
+                    "with recurse=True. Expected a fully parsed ForcingModel, a "
+                    "scalar float, or the 'realtime' keyword."
+                )
+    return v
+
+
+ForcingData = Annotated[
+    Union[float, RealTime, ForcingModel, DiskOnlyFileModel],
+    AfterValidator(_reject_disk_only_on_recursive_load),
+]
+"""Data type that selects from four different types of forcing data:
 *   a scalar float constant
 *   "realtime" keyword, indicating externally controlled.
 *   A ForcingModel coming from a .bc file.
+*   A DiskOnlyFileModel placeholder when the file is loaded non-recursively
+    (i.e. ``recurse=False``). In that mode, `resolve_file_model` returns a
+    lightweight stub instead of fully parsing the .bc file.
+
+Note:
+    Raw values never reach Pydantic's Union resolution directly — a
+    ``@field_validator(mode="before")`` calling ``_resolve_forcing_data``
+    always resolves strings/paths into the correct type *before* Pydantic
+    performs Union matching. ``DiskOnlyFileModel`` is listed here solely so
+    Pydantic accepts the already-constructed instance returned by the
+    before-validator under non-recursive loads. The ``AfterValidator``
+    rejects ``DiskOnlyFileModel`` if the load context has ``recurse=True``,
+    catching pipeline bugs early.
 """

--- a/hydrolib/core/dflowfm/bc/models.py
+++ b/hydrolib/core/dflowfm/bc/models.py
@@ -38,6 +38,7 @@ from pydantic import (
 from pydantic_core import core_schema
 from strenum import StrEnum
 
+from hydrolib.core.base import DiskOnlyFileModel
 from hydrolib.core.base.models import BaseModel, ModelSaveSettings
 from hydrolib.core.base.utils import to_list
 from hydrolib.core.dflowfm.ini.io_models import Property, Section
@@ -1224,7 +1225,7 @@ class RealTime(StrEnum):
     """str: Realtime data source, externally provided"""
 
 
-ForcingData = Union[float, RealTime, ForcingModel]
+ForcingData = Union[float, RealTime, ForcingModel, DiskOnlyFileModel]
 """Data type that selects from three different types of forcing data:
 *   a scalar float constant
 *   "realtime" keyword, indicating externally controlled.

--- a/hydrolib/core/dflowfm/ext/models.py
+++ b/hydrolib/core/dflowfm/ext/models.py
@@ -76,7 +76,7 @@ def _is_dynamic_forcing_delta_key(key: Any) -> bool:
 
 def _resolve_forcing_data(
     v: Any, *, allow_realtime: bool = True
-) -> float | RealTime | ForcingModel | None:
+) -> float | RealTime | ForcingModel | None | DiskOnlyFileModel:
     """Coerce a raw value into a `ForcingData` member (float, RealTime, or ForcingModel).
 
     A string is tried as a float, then as the `RealTime` enum (case-insensitive),

--- a/hydrolib/core/dflowfm/ext/models.py
+++ b/hydrolib/core/dflowfm/ext/models.py
@@ -77,13 +77,21 @@ def _is_dynamic_forcing_delta_key(key: Any) -> bool:
 def _resolve_forcing_data(
     v: Any, *, allow_realtime: bool = True
 ) -> float | RealTime | ForcingModel | None | DiskOnlyFileModel:
-    """Coerce a raw value into a `ForcingData` member (float, RealTime, or ForcingModel).
+    """Coerce a raw value into a `ForcingData` member (float, RealTime, ForcingModel, or DiskOnlyFileModel).
 
     A string is tried as a float, then as the `RealTime` enum (case-insensitive),
     and finally resolved as a path to a `.bc` forcing file. A `Path` is always
     resolved as a forcing file. A `dict` is instantiated as a `ForcingModel`.
     Any other value (including `None`) is passed through unchanged so that
     Optional fields and already-validated values still work.
+
+    When the active file-load context has ``recurse=False``, the path resolution
+    step returns a ``DiskOnlyFileModel`` instead of fully parsing the `.bc` file
+    into a ``ForcingModel``. This lightweight placeholder avoids expensive I/O
+    during non-recursive loads while still satisfying the ``ForcingData`` type
+    annotation. An ``AfterValidator`` on ``ForcingData`` ensures that a
+    ``DiskOnlyFileModel`` can never slip through under a recursive load
+    (``recurse=True``), where the `.bc` file is expected to be fully parsed.
 
     Args:
         v: The raw value to coerce.
@@ -93,6 +101,11 @@ def _resolve_forcing_data(
             `realtime` is "not (yet) available for sediment fractions and
             tracers", so callers handling `tracer<...>Delta` /
             `sedFrac<...>Delta` keys should pass `allow_realtime=False`.
+
+    Returns:
+        float | RealTime | ForcingModel | DiskOnlyFileModel | None:
+            The resolved forcing data value. ``DiskOnlyFileModel`` is returned
+            only when ``recurse=False`` in the active file-load context.
 
     Raises:
         ValueError: When `v` is the `realtime` keyword (any case) and

--- a/hydrolib/tools/extforce_convert/mdu_parser.py
+++ b/hydrolib/tools/extforce_convert/mdu_parser.py
@@ -889,7 +889,7 @@ class MDUParser:
 
     def find_keyword_lines(
         self, keyword: str, case_sensitive: bool = False, exact_match: bool = False
-    ) -> Union[int, None]:
+    ) -> int | None:
         """Find line numbers in the MDU file where the keyword appears.
 
         Args:

--- a/hydrolib/tools/extforce_convert/mdu_parser.py
+++ b/hydrolib/tools/extforce_convert/mdu_parser.py
@@ -851,7 +851,7 @@ class MDUParser:
                 self.content.pop(ext_force_line)
 
         if remove_old_ext_file:
-            old_ext_force_line = self.find_keyword_lines("ExtForceFile")
+            old_ext_force_line = self.find_keyword_lines("ExtForceFile", exact_match=True)
             if old_ext_force_line is not None:
                 self.content.pop(old_ext_force_line)
 
@@ -888,28 +888,32 @@ class MDUParser:
         return temperature_and_salinity_info
 
     def find_keyword_lines(
-        self, keyword: str, case_sensitive: bool = False
+        self, keyword: str, case_sensitive: bool = False, exact_match: bool = False
     ) -> Union[int, None]:
         """Find line numbers in the MDU file where the keyword appears.
 
         Args:
             keyword: The keyword to search for.
             case_sensitive: Whether the search should be case-sensitive.
+            exact_match: When True, only match lines where the keyword is
+                followed by a word boundary (whitespace, ``=`` or end of line),
+                so searching for ``ExtForceFile`` does not match a line that
+                starts with ``ExtForceFileNew``.
 
         Returns:
             A list of line number where the keyword is found.
         """
-        if not case_sensitive:
-            keyword = keyword.lower()
+        needle = keyword if case_sensitive else keyword.lower()
         line_number = None
         for i, line in enumerate(self.content, start=0):
             haystack = line if case_sensitive else line.lower()
             stripped_line = haystack.lstrip()
-            if_exist = (
-                stripped_line.startswith(keyword)
-                if case_sensitive
-                else stripped_line.lower().startswith(keyword.lower())
-            )
+            if_exist = stripped_line.startswith(needle)
+            if if_exist and exact_match:
+                remainder = stripped_line[len(needle):]
+                if_exist = remainder == "" or not (
+                    remainder[0].isalnum() or remainder[0] == "_"
+                )
             if if_exist:
                 line_number = i
                 break

--- a/hydrolib/tools/extforce_convert/mdu_parser.py
+++ b/hydrolib/tools/extforce_convert/mdu_parser.py
@@ -901,7 +901,7 @@ class MDUParser:
                 starts with ``ExtForceFileNew``.
 
         Returns:
-            A list of line number where the keyword is found.
+            The 0-based line index where the keyword is found, or None if not found.
         """
         needle = keyword if case_sensitive else keyword.lower()
         line_number = None

--- a/tests/data/input/forcing_data_disk_only/discharge.bc
+++ b/tests/data/input/forcing_data_disk_only/discharge.bc
@@ -1,0 +1,15 @@
+[General]
+fileVersion = 1.01
+fileType    = boundConds
+
+[Forcing]
+name     = Q_S
+function = timeseries
+timeInterpolation = linear
+quantity = time
+unit     = minutes since 2015-01-01 00:00:00
+quantity = dischargebnd
+unit     = m³/s
+0.0    1.0
+60.0   2.0
+

--- a/tests/data/input/forcing_data_disk_only/minimal.ext
+++ b/tests/data/input/forcing_data_disk_only/minimal.ext
@@ -1,0 +1,13 @@
+# Minimal ext file for e2e ForcingData validator test
+
+[General]
+fileVersion = 2.01
+fileType    = extForce
+
+[SourceSink]
+id             = Q_S
+numCoordinates = 1
+xCoordinates   = 104.048386
+yCoordinates   = 1.41122
+discharge      = discharge.bc
+

--- a/tests/dflowfm/bc/test_forcing_data_validator.py
+++ b/tests/dflowfm/bc/test_forcing_data_validator.py
@@ -9,6 +9,8 @@ Module under test:
     `hydrolib.core.dflowfm.bc.models._reject_disk_only_on_recursive_load`
 """
 
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
@@ -26,6 +28,13 @@ from hydrolib.core.dflowfm.bc.models import (
 from hydrolib.core.dflowfm.ext.models import Lateral, SourceSink
 
 
+@pytest.fixture
+def forcing_data_ext_file() -> Path:
+    """Path to the minimal ext file for e2e tests."""
+    return Path("tests/data/input/forcing_data_disk_only/minimal.ext")
+
+
+@pytest.mark.unit
 class TestRejectDiskOnlyOnRecursiveLoad:
     """Tests for _reject_disk_only_on_recursive_load validator function."""
 
@@ -227,6 +236,7 @@ class TestRejectDiskOnlyOnRecursiveLoad:
             context_file_loading.reset(token)
 
 
+@pytest.mark.integration
 class TestForcingDataIntegration:
     """Integration tests verifying the AfterValidator works within Pydantic model validation."""
 
@@ -348,4 +358,22 @@ class TestForcingDataIntegration:
             context_file_loading.reset(token)
 
 
+@pytest.mark.e2e
+class TestForcingDataE2E:
+    """End-to-end tests loading a real ext file with recurse=True/False."""
 
+    def test_load_ext_file_non_recursive_produces_disk_only(self, forcing_data_ext_file):
+        """Loading an ext file with recurse=False yields DiskOnlyFileModel for .bc references."""
+        from hydrolib.core.dflowfm.ext.models import ExtModel
+
+        model = ExtModel(filepath=forcing_data_ext_file, recurse=False)
+        ss = model.sourcesink[0]
+        assert isinstance(ss.discharge, DiskOnlyFileModel)
+
+    def test_load_ext_file_recursive_produces_forcing_model(self, forcing_data_ext_file):
+        """Loading an ext file with recurse=True fully parses .bc into ForcingModel."""
+        from hydrolib.core.dflowfm.ext.models import ExtModel
+
+        model = ExtModel(filepath=forcing_data_ext_file, recurse=True)
+        ss = model.sourcesink[0]
+        assert isinstance(ss.discharge, ForcingModel)

--- a/tests/dflowfm/bc/test_forcing_data_validator.py
+++ b/tests/dflowfm/bc/test_forcing_data_validator.py
@@ -1,0 +1,351 @@
+"""Tests for the ``_reject_disk_only_on_recursive_load`` AfterValidator on ``ForcingData``.
+
+This module validates that the ``AfterValidator`` correctly guards the ``ForcingData``
+annotated Union so that ``DiskOnlyFileModel`` is only accepted when the file load
+context has ``recurse=False``. Under a recursive load (``recurse=True``), a
+``DiskOnlyFileModel`` value must be rejected with a clear ``ValueError``.
+
+Module under test:
+    ``hydrolib.core.dflowfm.bc.models._reject_disk_only_on_recursive_load``
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from hydrolib.core.base import DiskOnlyFileModel
+from hydrolib.core.base.file_manager import (
+    FileLoadContext,
+    context_file_loading,
+)
+from hydrolib.core.base.utils import PathStyle
+from hydrolib.core.dflowfm.bc.models import (
+    ForcingModel,
+    RealTime,
+    _reject_disk_only_on_recursive_load,
+)
+from hydrolib.core.dflowfm.ext.models import Lateral, SourceSink
+
+
+class TestRejectDiskOnlyOnRecursiveLoad:
+    """Tests for _reject_disk_only_on_recursive_load validator function."""
+
+    def test_non_disk_only_float_passes_through(self):
+        """Float values pass through the validator unchanged.
+
+        Test scenario:
+            A float (valid ForcingData member) should be returned as-is regardless
+            of load context, since the guard only checks DiskOnlyFileModel instances.
+        """
+        result = _reject_disk_only_on_recursive_load(3.14)
+        assert result == 3.14, f"Expected 3.14, got {result}"
+
+    def test_non_disk_only_realtime_passes_through(self):
+        """RealTime enum values pass through the validator unchanged.
+
+        Test scenario:
+            RealTime.realtime should be returned as-is regardless of load context.
+        """
+        result = _reject_disk_only_on_recursive_load(RealTime.realtime)
+        assert result is RealTime.realtime, f"Expected RealTime.realtime, got {result!r}"
+
+    def test_non_disk_only_forcing_model_passes_through(self):
+        """ForcingModel instances pass through the validator unchanged.
+
+        Test scenario:
+            A ForcingModel is the expected type under recursive loads, so it must
+            never be rejected.
+        """
+        model = ForcingModel()
+        result = _reject_disk_only_on_recursive_load(model)
+        assert result is model, "ForcingModel should be returned by identity"
+
+    def test_none_passes_through(self):
+        """None passes through unchanged (for Optional[ForcingData] fields).
+
+        Test scenario:
+            None is not a DiskOnlyFileModel, so the isinstance check short-circuits
+            and None is returned unchanged.
+        """
+        result = _reject_disk_only_on_recursive_load(None)
+        assert result is None, f"None should pass through, got {result!r}"
+
+    def test_disk_only_rejected_when_recurse_true(self):
+        """DiskOnlyFileModel is rejected when the load context has recurse=True.
+
+        Test scenario:
+            Simulate a recursive load by setting up a FileLoadContext with
+            ``recurse=True``. The validator must raise a ValueError explaining
+            that DiskOnlyFileModel is not valid in this context.
+        """
+        ctx = FileLoadContext()
+        ctx.initialize_load_settings(
+            recurse=True, resolve_casing=False, path_style=PathStyle.UNIXLIKE
+        )
+        token = context_file_loading.set(ctx)
+        try:
+            disk_model = DiskOnlyFileModel(filepath=None)
+            with pytest.raises(ValueError, match="not valid for ForcingData"):
+                _reject_disk_only_on_recursive_load(disk_model)
+        finally:
+            context_file_loading.reset(token)
+
+    def test_disk_only_accepted_when_recurse_false(self):
+        """DiskOnlyFileModel is accepted when the load context has recurse=False.
+
+        Test scenario:
+            Simulate a non-recursive load by setting up a FileLoadContext with
+            ``recurse=False``. The validator must allow DiskOnlyFileModel through
+            since this is the legitimate case.
+        """
+        ctx = FileLoadContext()
+        ctx.initialize_load_settings(
+            recurse=False, resolve_casing=False, path_style=PathStyle.UNIXLIKE
+        )
+        token = context_file_loading.set(ctx)
+        try:
+            disk_model = DiskOnlyFileModel(filepath=None)
+            result = _reject_disk_only_on_recursive_load(disk_model)
+            assert result is disk_model, (
+                f"DiskOnlyFileModel should pass through when recurse=False, got {result!r}"
+            )
+        finally:
+            context_file_loading.reset(token)
+
+    def test_disk_only_accepted_when_no_load_context(self):
+        """DiskOnlyFileModel is accepted when no file load context exists.
+
+        Test scenario:
+            When models are constructed programmatically (outside of file loading),
+            there is no active FileLoadContext (or _load_settings is None).
+            The validator must not reject DiskOnlyFileModel in this case, allowing
+            manual model construction.
+        """
+        # Ensure no context is set
+        token = context_file_loading.set(FileLoadContext())
+        context_file_loading.reset(token)
+
+        disk_model = DiskOnlyFileModel(filepath=None)
+        result = _reject_disk_only_on_recursive_load(disk_model)
+        assert result is disk_model, (
+            "DiskOnlyFileModel should pass through when no load context is active"
+        )
+
+    def test_disk_only_accepted_when_load_settings_not_initialized(self):
+        """DiskOnlyFileModel is accepted when load settings have not been initialized.
+
+        Test scenario:
+            A FileLoadContext exists but ``initialize_load_settings`` was never called,
+            so ``_load_settings`` is None. The validator must not reject
+            DiskOnlyFileModel in this case.
+        """
+        ctx = FileLoadContext()
+        # Do NOT call ctx.initialize_load_settings(...)
+        token = context_file_loading.set(ctx)
+        try:
+            disk_model = DiskOnlyFileModel(filepath=None)
+            result = _reject_disk_only_on_recursive_load(disk_model)
+            assert result is disk_model, (
+                "DiskOnlyFileModel should pass through when _load_settings is None"
+            )
+        finally:
+            context_file_loading.reset(token)
+
+    def test_error_message_is_descriptive(self):
+        """The ValueError message mentions the expected types and the cause.
+
+        Test scenario:
+            Verify the error message contains actionable information: it should
+            mention DiskOnlyFileModel, recurse=True, and the valid alternatives.
+        """
+        ctx = FileLoadContext()
+        ctx.initialize_load_settings(
+            recurse=True, resolve_casing=False, path_style=PathStyle.UNIXLIKE
+        )
+        token = context_file_loading.set(ctx)
+        try:
+            disk_model = DiskOnlyFileModel(filepath=None)
+            with pytest.raises(ValueError) as exc_info:
+                _reject_disk_only_on_recursive_load(disk_model)
+
+            msg = str(exc_info.value)
+            assert "DiskOnlyFileModel" in msg, (
+                f"Error should mention DiskOnlyFileModel, got: {msg}"
+            )
+            assert "recurse=True" in msg, (
+                f"Error should mention recurse=True, got: {msg}"
+            )
+            assert "ForcingModel" in msg, (
+                f"Error should mention ForcingModel as alternative, got: {msg}"
+            )
+        finally:
+            context_file_loading.reset(token)
+
+    def test_disk_only_with_filepath_rejected_when_recurse_true(self):
+        """DiskOnlyFileModel with an actual filepath is also rejected under recurse=True.
+
+        Test scenario:
+            Even if the DiskOnlyFileModel carries a real path, it should be rejected
+            under recursive loading — the expectation is that the file should have
+            been fully parsed into a ForcingModel.
+        """
+        ctx = FileLoadContext()
+        ctx.initialize_load_settings(
+            recurse=True, resolve_casing=False, path_style=PathStyle.UNIXLIKE
+        )
+        token = context_file_loading.set(ctx)
+        try:
+            disk_model = DiskOnlyFileModel(filepath="some/file.bc")
+            with pytest.raises(ValueError, match="not valid for ForcingData"):
+                _reject_disk_only_on_recursive_load(disk_model)
+        finally:
+            context_file_loading.reset(token)
+
+    @pytest.mark.parametrize(
+        "value",
+        [0.0, -1.5, 1e10, ""],
+        ids=["zero", "negative", "large", "empty_string"],
+    )
+    def test_non_disk_only_values_always_pass_through(self, value):
+        """Non-DiskOnlyFileModel values always pass through regardless of context.
+
+        Args:
+            value: Various non-DiskOnlyFileModel values to test passthrough.
+
+        Test scenario:
+            The isinstance(v, DiskOnlyFileModel) check should short-circuit for
+            any value that is not a DiskOnlyFileModel instance.
+        """
+        ctx = FileLoadContext()
+        ctx.initialize_load_settings(
+            recurse=True, resolve_casing=False, path_style=PathStyle.UNIXLIKE
+        )
+        token = context_file_loading.set(ctx)
+        try:
+            result = _reject_disk_only_on_recursive_load(value)
+            assert result == value, f"Expected {value!r} to pass through, got {result!r}"
+        finally:
+            context_file_loading.reset(token)
+
+
+class TestForcingDataIntegration:
+    """Integration tests verifying the AfterValidator works within Pydantic model validation."""
+
+    def test_lateral_accepts_disk_only_under_non_recursive_load(self):
+        """A Lateral model accepts DiskOnlyFileModel for discharge when recurse=False.
+
+        Test scenario:
+            Simulate the real workflow: a non-recursive load produces a
+            DiskOnlyFileModel from resolve_file_model, then Pydantic validates
+            it into the Lateral.discharge field. The AfterValidator must allow it.
+        """
+        ctx = FileLoadContext()
+        ctx.initialize_load_settings(
+            recurse=False, resolve_casing=False, path_style=PathStyle.UNIXLIKE
+        )
+        token = context_file_loading.set(ctx)
+        try:
+            disk_model = DiskOnlyFileModel(filepath=None)
+            lateral = Lateral(
+                id="test_lateral",
+                name="test",
+                discharge=disk_model,
+                locationType="1d",
+                branchId="branch1",
+                chainage=100.0,
+            )
+            assert isinstance(lateral.discharge, DiskOnlyFileModel), (
+                f"Expected DiskOnlyFileModel, got {type(lateral.discharge).__name__}"
+            )
+        finally:
+            context_file_loading.reset(token)
+
+    def test_lateral_rejects_disk_only_under_recursive_load(self):
+        """A Lateral model rejects DiskOnlyFileModel for discharge when recurse=True.
+
+        Test scenario:
+            Simulate a recursive load context and attempt to assign a
+            DiskOnlyFileModel to the discharge field. Pydantic's AfterValidator
+            should reject it with a ValidationError.
+        """
+        ctx = FileLoadContext()
+        ctx.initialize_load_settings(
+            recurse=True, resolve_casing=False, path_style=PathStyle.UNIXLIKE
+        )
+        token = context_file_loading.set(ctx)
+        try:
+            disk_model = DiskOnlyFileModel(filepath=None)
+            with pytest.raises(ValidationError) as exc_info:
+                Lateral(
+                    id="test_lateral",
+                    name="test",
+                    discharge=disk_model,
+                    locationType="1d",
+                    branchId="branch1",
+                    chainage=100.0,
+                )
+            assert "DiskOnlyFileModel" in str(exc_info.value), (
+                f"ValidationError should mention DiskOnlyFileModel, got: {exc_info.value}"
+            )
+        finally:
+            context_file_loading.reset(token)
+
+    def test_lateral_accepts_float_under_recursive_load(self):
+        """A Lateral model accepts float discharge values under recursive load.
+
+        Test scenario:
+            Float is always valid for ForcingData regardless of load context.
+            Confirms the AfterValidator doesn't interfere with non-DiskOnlyFileModel values.
+        """
+
+        ctx = FileLoadContext()
+        ctx.initialize_load_settings(
+            recurse=True, resolve_casing=False, path_style=PathStyle.UNIXLIKE
+        )
+        token = context_file_loading.set(ctx)
+        try:
+            lateral = Lateral(
+                id="test_lateral",
+                name="test",
+                discharge=5.0,
+                locationType="1d",
+                branchId="branch1",
+                chainage=100.0,
+            )
+            assert lateral.discharge == 5.0, (
+                f"Expected discharge=5.0, got {lateral.discharge}"
+            )
+        finally:
+            context_file_loading.reset(token)
+
+    def test_source_sink_accepts_disk_only_under_non_recursive_load(self):
+        """A SourceSink model accepts DiskOnlyFileModel under non-recursive load.
+
+        Test scenario:
+            SourceSink has multiple ForcingData fields (discharge, salinitydelta,
+            temperaturedelta). Verify the AfterValidator allows DiskOnlyFileModel
+            for the main discharge field when recurse=False.
+        """
+
+        ctx = FileLoadContext()
+        ctx.initialize_load_settings(
+            recurse=False, resolve_casing=False, path_style=PathStyle.UNIXLIKE
+        )
+        token = context_file_loading.set(ctx)
+        try:
+            disk_model = DiskOnlyFileModel(filepath=None)
+            source_sink = SourceSink(
+                id="test_ss",
+                name="test",
+                discharge=disk_model,
+                numCoordinates=1,
+                xCoordinates=[0.0],
+                yCoordinates=[0.0],
+            )
+            assert isinstance(source_sink.discharge, DiskOnlyFileModel), (
+                f"Expected DiskOnlyFileModel, got {type(source_sink.discharge).__name__}"
+            )
+        finally:
+            context_file_loading.reset(token)
+
+
+

--- a/tests/dflowfm/bc/test_forcing_data_validator.py
+++ b/tests/dflowfm/bc/test_forcing_data_validator.py
@@ -1,12 +1,12 @@
-"""Tests for the ``_reject_disk_only_on_recursive_load`` AfterValidator on ``ForcingData``.
+"""Tests for the `_reject_disk_only_on_recursive_load` AfterValidator on `ForcingData`.
 
-This module validates that the ``AfterValidator`` correctly guards the ``ForcingData``
-annotated Union so that ``DiskOnlyFileModel`` is only accepted when the file load
-context has ``recurse=False``. Under a recursive load (``recurse=True``), a
-``DiskOnlyFileModel`` value must be rejected with a clear ``ValueError``.
+This module validates that the `AfterValidator` correctly guards the `ForcingData`
+annotated Union so that `DiskOnlyFileModel` is only accepted when the file load
+context has `recurse=False`. Under a recursive load (`recurse=True`), a
+`DiskOnlyFileModel` value must be rejected with a clear `ValueError`.
 
 Module under test:
-    ``hydrolib.core.dflowfm.bc.models._reject_disk_only_on_recursive_load``
+    `hydrolib.core.dflowfm.bc.models._reject_disk_only_on_recursive_load`
 """
 
 import pytest
@@ -74,7 +74,7 @@ class TestRejectDiskOnlyOnRecursiveLoad:
 
         Test scenario:
             Simulate a recursive load by setting up a FileLoadContext with
-            ``recurse=True``. The validator must raise a ValueError explaining
+            `recurse=True`. The validator must raise a ValueError explaining
             that DiskOnlyFileModel is not valid in this context.
         """
         ctx = FileLoadContext()
@@ -94,7 +94,7 @@ class TestRejectDiskOnlyOnRecursiveLoad:
 
         Test scenario:
             Simulate a non-recursive load by setting up a FileLoadContext with
-            ``recurse=False``. The validator must allow DiskOnlyFileModel through
+            `recurse=False`. The validator must allow DiskOnlyFileModel through
             since this is the legitimate case.
         """
         ctx = FileLoadContext()
@@ -134,8 +134,8 @@ class TestRejectDiskOnlyOnRecursiveLoad:
         """DiskOnlyFileModel is accepted when load settings have not been initialized.
 
         Test scenario:
-            A FileLoadContext exists but ``initialize_load_settings`` was never called,
-            so ``_load_settings`` is None. The validator must not reject
+            A FileLoadContext exists but `initialize_load_settings` was never called,
+            so `_load_settings` is None. The validator must not reject
             DiskOnlyFileModel in this case.
         """
         ctx = FileLoadContext()

--- a/tests/tools/mdu_parser/test_mdu_parser.py
+++ b/tests/tools/mdu_parser/test_mdu_parser.py
@@ -198,6 +198,58 @@ class TestMduParser:
         # Test with a keyword that doesn't exist
         assert parser.find_keyword_lines("NonExistentKeyword") is None
 
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "keyword, case_sensitive, exact_match, expected",
+        [
+            ("ExtForceFile", False, False, 1),
+            ("ExtForceFile", False, True, 2),
+            ("ExtForceFileNew", False, True, 1),
+            ("extforcefile", False, True, 2),
+            ("extforcefile", True, True, None),
+            ("Missing", False, True, None),
+        ],
+        ids=[
+            "prefix match returns first",
+            "exact skips longer keyword",
+            "exact matches new keyword",
+            "exact case-insensitive",
+            "exact case-sensitive no match",
+            "keyword absent",
+        ],
+    )
+    def test_find_keyword_lines_exact_match(
+        self, keyword, case_sensitive, exact_match, expected
+    ):
+        """Test find_keyword_lines honours the exact_match word boundary.
+
+        Args:
+            keyword: The keyword searched for.
+            case_sensitive: Whether the search is case-sensitive.
+            exact_match: Whether a trailing word boundary is required.
+            expected: The expected 0-based line index (or None).
+
+        Test scenario:
+            ``ExtForceFileNew`` precedes ``ExtForceFile``. A prefix search for
+            ``ExtForceFile`` returns the ``ExtForceFileNew`` line (index 1), while
+            an exact-match search requires a boundary after the keyword and returns
+            the genuine ``ExtForceFile`` line (index 2). Case handling is preserved.
+        """
+        parser = MagicMock(spec=MDUParser)
+        parser.find_keyword_lines = types.MethodType(
+            MDUParser.find_keyword_lines, parser
+        )
+        parser.content = [
+            "[external forcing]\n",
+            "ExtForceFileNew = new.ext\n",
+            "ExtForceFile = old.ext\n",
+        ]
+
+        result = MDUParser.find_keyword_lines(
+            parser, keyword, case_sensitive=case_sensitive, exact_match=exact_match
+        )
+        assert result == expected, f"Expected {expected}, got {result}"
+
     def test_insert_line(self):
         parser = MDUParser(self.file_path)
         new_line = "NewLine = value\n"
@@ -1493,3 +1545,228 @@ class GetNewExtforceFile:
         block.root_dir = None
         with pytest.raises(Exception):
             block.get_new_extforce_file()
+
+
+class TestUpdateExtForceFileNew:
+    """Tests for MDUParser.update_extforce_file_new.
+
+    These tests focus on the ``exact_match`` behaviour used when removing the old
+    ``ExtForceFile`` entry: searching for ``ExtForceFile`` must not match an
+    ``ExtForceFileNew`` line that merely shares the same prefix.
+    """
+
+    @staticmethod
+    def _make_parser(content):
+        """Build a lightweight MDUParser mock wired for update_extforce_file_new.
+
+        Args:
+            content: The list of MDU lines the mocked parser should operate on.
+
+        Returns:
+            MagicMock: A mock configured with the real methods needed by
+            ``update_extforce_file_new`` and its collaborators.
+        """
+        parser = MagicMock(spec=MDUParser)
+        parser.update_extforce_file_new = types.MethodType(
+            MDUParser.update_extforce_file_new, parser
+        )
+        parser.update_file_entry = types.MethodType(MDUParser.update_file_entry, parser)
+        parser.has_field = types.MethodType(MDUParser.has_field, parser)
+        parser.find_keyword_lines = types.MethodType(
+            MDUParser.find_keyword_lines, parser
+        )
+        parser.get_section = types.MethodType(MDUParser.get_section, parser)
+        parser.insert_line = types.MethodType(MDUParser.insert_line, parser)
+        parser.file_style_properties = FileStyleProperties(content)
+        parser.content = deepcopy(content)
+        return parser
+
+    @pytest.mark.unit
+    def test_exact_match_preserves_new_entry_when_removing_old(self):
+        """Removing the old file must not delete ExtForceFileNew via prefix match.
+
+        Test scenario:
+            The section contains only an ``ExtForceFileNew`` entry (no plain
+            ``ExtForceFile``). With ``remove_old_ext_file=True`` and a positive
+            quantity count, the old-file removal step searches for
+            ``ExtForceFile``; without ``exact_match`` it would wrongly match and
+            delete the ``ExtForceFileNew`` line. The entry must be preserved.
+        """
+        content = [
+            "[external forcing]\n",
+            "ExtForceFileNew = existing_new.ext\n",
+            "[geometry]\n",
+            "NetFile = test.nc\n",
+        ]
+        parser = self._make_parser(content)
+
+        parser.update_extforce_file_new("new.ext", 1, remove_old_ext_file=True)
+
+        new_lines = [line for line in parser.content if "ExtForceFileNew" in line]
+        assert (
+            len(new_lines) == 1
+        ), f"ExtForceFileNew should be preserved, content is: {parser.content}"
+        keys = [Line(line).key for line in parser.content if "=" in line]
+        assert (
+            "ExtForceFile" not in keys
+        ), f"No plain ExtForceFile line should remain, content is: {parser.content}"
+
+    @pytest.mark.unit
+    def test_removes_old_when_new_precedes_old(self):
+        """The old ExtForceFile is removed even when it comes after ExtForceFileNew.
+
+        Test scenario:
+            ``ExtForceFileNew`` appears before ``ExtForceFile`` in the section.
+            The exact-match search must skip the ``ExtForceFileNew`` line and
+            remove the genuine ``ExtForceFile`` line, leaving the new entry intact.
+        """
+        content = [
+            "[external forcing]\n",
+            "ExtForceFileNew = existing_new.ext\n",
+            "ExtForceFile = old.ext\n",
+            "[geometry]\n",
+            "NetFile = test.nc\n",
+        ]
+        parser = self._make_parser(content)
+
+        parser.update_extforce_file_new("new.ext", 1, remove_old_ext_file=True)
+
+        keys = [Line(line).key for line in parser.content if "=" in line]
+        assert (
+            "ExtForceFileNew" in keys
+        ), f"ExtForceFileNew should remain, content is: {parser.content}"
+        assert (
+            "ExtForceFile" not in keys
+        ), f"Old ExtForceFile should be removed, content is: {parser.content}"
+
+    @pytest.mark.unit
+    def test_num_quantities_zero_removes_new_entry(self):
+        """A zero quantity count removes the ExtForceFileNew entry.
+
+        Test scenario:
+            With ``num_quantities == 0`` and ``remove_old_ext_file=False``, the
+            existing ``ExtForceFileNew`` line is removed and everything else is
+            left untouched.
+        """
+        content = [
+            "[external forcing]\n",
+            "ExtForceFileNew = existing_new.ext\n",
+            "[geometry]\n",
+            "NetFile = test.nc\n",
+        ]
+        parser = self._make_parser(content)
+
+        parser.update_extforce_file_new("new.ext", 0, remove_old_ext_file=False)
+
+        assert not any(
+            "ExtForceFileNew" in line for line in parser.content
+        ), f"ExtForceFileNew should be removed, content is: {parser.content}"
+        assert (
+            len(parser.content) == 3
+        ), f"Only the ExtForceFileNew line should be removed, content is: {parser.content}"
+
+    @pytest.mark.unit
+    def test_num_quantities_zero_removes_new_and_old(self):
+        """A zero quantity count with remove_old removes both new and old entries.
+
+        Test scenario:
+            The section contains both ``ExtForceFileNew`` and ``ExtForceFile``.
+            With ``num_quantities == 0`` and ``remove_old_ext_file=True`` both
+            entries are removed.
+        """
+        content = [
+            "[external forcing]\n",
+            "ExtForceFile = old.ext\n",
+            "ExtForceFileNew = existing_new.ext\n",
+            "[geometry]\n",
+            "NetFile = test.nc\n",
+        ]
+        parser = self._make_parser(content)
+
+        parser.update_extforce_file_new("new.ext", 0, remove_old_ext_file=True)
+
+        keys = [Line(line).key for line in parser.content if "=" in line]
+        assert (
+            "ExtForceFileNew" not in keys
+        ), f"ExtForceFileNew should be removed, content is: {parser.content}"
+        assert (
+            "ExtForceFile" not in keys
+        ), f"ExtForceFile should be removed, content is: {parser.content}"
+
+    @pytest.mark.unit
+    def test_remove_old_false_keeps_old(self):
+        """When remove_old_ext_file is False the old ExtForceFile is kept.
+
+        Test scenario:
+            With a positive quantity count and ``remove_old_ext_file=False`` the
+            existing ``ExtForceFile`` line remains in the content.
+        """
+        content = [
+            "[external forcing]\n",
+            "ExtForceFile = old.ext\n",
+            "ExtForceFileNew = existing_new.ext\n",
+            "[geometry]\n",
+            "NetFile = test.nc\n",
+        ]
+        parser = self._make_parser(content)
+
+        parser.update_extforce_file_new("new.ext", 1, remove_old_ext_file=False)
+
+        keys = [Line(line).key for line in parser.content if "=" in line]
+        assert (
+            "ExtForceFile" in keys
+        ), f"ExtForceFile should be kept, content is: {parser.content}"
+
+    @pytest.mark.unit
+    def test_positive_quantities_inserts_new_and_removes_old(self):
+        """A positive count inserts ExtForceFileNew and removes the old entry.
+
+        Test scenario:
+            The section contains only ``ExtForceFile``. With a positive quantity
+            count and ``remove_old_ext_file=True`` a new ``ExtForceFileNew`` entry
+            is inserted with the given value and the old ``ExtForceFile`` line is
+            removed.
+        """
+        content = [
+            "[external forcing]\n",
+            "ExtForceFile = old.ext\n",
+            "[geometry]\n",
+            "NetFile = test.nc\n",
+        ]
+        parser = self._make_parser(content)
+
+        parser.update_extforce_file_new("new.ext", 1, remove_old_ext_file=True)
+
+        keys = [Line(line).key for line in parser.content if "=" in line]
+        assert (
+            "ExtForceFileNew" in keys
+        ), f"ExtForceFileNew should be inserted, content is: {parser.content}"
+        assert (
+            "ExtForceFile" not in keys
+        ), f"Old ExtForceFile should be removed, content is: {parser.content}"
+        new_line = next(line for line in parser.content if "ExtForceFileNew" in line)
+        assert (
+            "new.ext" in new_line
+        ), f"Inserted line should carry the new value, got: {new_line}"
+
+    @pytest.mark.unit
+    def test_no_extforce_lines_is_noop(self):
+        """Absent extforce entries leave the content unchanged without error.
+
+        Test scenario:
+            The section has neither ``ExtForceFile`` nor ``ExtForceFileNew``.
+            With ``num_quantities == 0`` and ``remove_old_ext_file=True`` the call
+            is a no-op and raises nothing.
+        """
+        content = [
+            "[external forcing]\n",
+            "[geometry]\n",
+            "NetFile = test.nc\n",
+        ]
+        parser = self._make_parser(content)
+
+        parser.update_extforce_file_new("new.ext", 0, remove_old_ext_file=True)
+
+        assert (
+            parser.content == content
+        ), f"Content should be unchanged, got: {parser.content}"


### PR DESCRIPTION
# Description
- **Widen `ForcingData` Union** to include `DiskOnlyFileModel` so that non-recursive
  file loads (`recurse=False`) can pass Pydantic validation on ext-model fields typed
  `ForcingData`.
- **Guard with `AfterValidator`**: a new `_reject_disk_only_on_recursive_load`
  validator rejects `DiskOnlyFileModel` when the load context has `recurse=True`,
  catching pipeline bugs early while allowing the legitimate non-recursive path.
- **Add `exact_match` to `MDUParser.find_keyword_lines`** to distinguish
  `ExtForceFile` from `ExtForceFileNew` when removing the old ext-force entry.
- **Fix `_resolve_forcing_data` return annotation** to include `DiskOnlyFileModel`.
- **Update `ForcingData` docstring** to document all four Union members and the
  `AfterValidator` contract.
- **Fix `find_keyword_lines` docstring** (previously said list, now correctly
  says single `int | None`).

# Issues
- Fixes #1068
- Fixes #1171
- Fixes #1145 
- Fixes #1143

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
# How Has This Been Tested?
- `pytest tests/ -x -q` — **2521 passed**, 10 skipped, 2 xfailed.
- New test file: `tests/dflowfm/bc/test_forcing_data_validator.py` (18 tests)
  covering the `AfterValidator` under all context states (recurse true/false/none)
  and integration with `Lateral` and `SourceSink` models.
- New tests in `tests/tools/mdu_parser/test_mdu_parser.py` for
  `find_keyword_lines(exact_match=...)` (6 parametrized cases) and
  `update_extforce_file_new` (7 scenario tests).
- [x] `test_forcing_data_validator.py` — 18 passed
- [x] `test_mdu_parser.py` — 142 passed
- [x] Full suite — 2521 passed

# Checklist:
- [ ] updated version number in setup.py/pyproject.toml/environment.yml.
- [ ] updated the lock file.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.