### PR TITLE
Feature/1165 check extforce convert for polygonfiles

### DIFF
--- a/hydrolib/tools/extforce_convert/converters.py
+++ b/hydrolib/tools/extforce_convert/converters.py
@@ -58,13 +58,12 @@ if TYPE_CHECKING:
     from hydrolib.tools.extforce_convert.mdu_parser import MDUParser
 
 
-#: Maps old-format "factor" quantity names to the base quantity they scale.
-#: These quantities are no longer needed in the new format; instead, the base
-#: quantity is used with ``operand = multiply``.
-FACTOR_QUANTITY_BASE: Dict[str, str] = {
-    "windspeedfactor": "windxy",
-    "solarradiationfactor": "solarradiation",
-}
+FACTOR_QUANTITIES = frozenset(
+    {
+        "windspeedfactor",
+        "solarradiationfactor",
+    }
+)
 
 
 class BaseConverter(ABC):
@@ -150,7 +149,7 @@ class SpatialBlockBuilder:
         self.new_forcing_path = new_forcing_path
 
         quantity_str = str(forcing.quantity).lower()
-        self._is_factor = quantity_str in FACTOR_QUANTITY_BASE
+        self._is_factor = quantity_str in FACTOR_QUANTITIES
 
         self.quantity_name = CONVERTER_DATA.external_forcing.rename_quantity(
             forcing.quantity

--- a/hydrolib/tools/extforce_convert/converters.py
+++ b/hydrolib/tools/extforce_convert/converters.py
@@ -189,8 +189,10 @@ class SpatialBlockBuilder:
                 operand value as parsed from the old external forcings block.
         """
         if self._is_factor:
-            return Operand.multiply
-        return self.forcing.operand
+            operand = Operand.multiply
+        else:
+            operand = self.forcing.operand
+        return operand
 
     def _set_representation(self):
         """Populate `self.block` with the spatial representation for this forcing.

--- a/hydrolib/tools/extforce_convert/converters.py
+++ b/hydrolib/tools/extforce_convert/converters.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from hydrolib.core.base.file_manager import PathOrStr, resolve_relative_to_root
 from hydrolib.core.base.models import DiskOnlyFileModel
+from hydrolib.core.dflowfm.common.models import Operand
 from hydrolib.core.dflowfm.bc.models import (
     T3D,
     Astronomic,
@@ -55,6 +56,15 @@ from hydrolib.tools.extforce_convert.utils import (
 
 if TYPE_CHECKING:
     from hydrolib.tools.extforce_convert.mdu_parser import MDUParser
+
+
+#: Maps old-format "factor" quantity names to the base quantity they scale.
+#: These quantities are no longer needed in the new format; instead, the base
+#: quantity is used with ``operand = multiply``.
+FACTOR_QUANTITY_BASE: Dict[str, str] = {
+    "windspeedfactor": "windxy",
+    "solarradiationfactor": "solarradiation",
+}
 
 
 class BaseConverter(ABC):
@@ -138,6 +148,10 @@ class SpatialBlockBuilder:
         """
         self.forcing = forcing
         self.new_forcing_path = new_forcing_path
+
+        quantity_str = str(forcing.quantity).lower()
+        self._is_factor = quantity_str in FACTOR_QUANTITY_BASE
+
         self.quantity_name = CONVERTER_DATA.external_forcing.rename_quantity(
             forcing.quantity
         )
@@ -164,6 +178,21 @@ class SpatialBlockBuilder:
                 f"{self.forcing.quantity} and FILENAME={self.forcing.filename}."
             )
 
+    def _set_operand(self) -> Operand:
+        """Return the operand for the new Spatial block.
+
+        Factor quantities (``windspeedfactor``, ``solarradiationfactor``) are
+        always converted with ``operand = multiply``, regardless of the operand
+        value recorded in the old external forcings file.
+
+        Returns:
+            Operand: ``Operand.multiply`` for factor quantities, otherwise the
+                operand value as parsed from the old external forcings block.
+        """
+        if self._is_factor:
+            return Operand.multiply
+        return self.forcing.operand
+
     def _set_representation(self):
         """Populate `self.block` with the spatial representation for this forcing.
 
@@ -188,7 +217,7 @@ class SpatialBlockBuilder:
                 "quantity": self.quantity_name,
                 "targetmaskfile": DiskOnlyFileModel(self.new_forcing_path),
                 "datavalue": self.forcing.value,
-                "operand": self.forcing.operand,
+                "operand": self._set_operand(),
                 "interpolationmethod": InterpolationMethod.constant,
             }
         elif is_polygon:
@@ -197,7 +226,7 @@ class SpatialBlockBuilder:
                 "datafile": DiskOnlyFileModel(self.new_forcing_path),
                 "datafiletype": self.file_type,
                 "interpolationmethod": InterpolationMethod.constant,
-                "operand": self.forcing.operand,
+                "operand": self._set_operand(),
             }
         else:
             self.block = {
@@ -208,7 +237,7 @@ class SpatialBlockBuilder:
             self.block = convert_interpolation_data(self.forcing, self.block)
             if is_initial_vertical:
                 self.block["interpolationmethod"] = InterpolationMethod.constant
-            self.block["operand"] = self.forcing.operand
+            self.block["operand"] = self._set_operand()
             self.block["extrapolationallowed"] = bool(
                 self.forcing.extrapolation_method
             )

--- a/hydrolib/tools/extforce_convert/data/data.yaml
+++ b/hydrolib/tools/extforce_convert/data/data.yaml
@@ -6,8 +6,6 @@ mdu:
 external_forcing:
     unsupported_quantity_names:
         # Meteo
-        - solarradiationfactor
-        - windspeedfactor
         - windstresscoefficient
         - wind_speed
         - wind_from_direction
@@ -58,4 +56,6 @@ external_forcing:
         # rejects it.
         bedrock_surface_elevation: bedrockSurfaceElevation
         friction_coefficient_time_dependent: frictionCoefficientTimeDependent
+        windspeedfactor: windxy
+        solarradiationfactor: solarradiation
 

--- a/tests/tools/test_converter_spatial.py
+++ b/tests/tools/test_converter_spatial.py
@@ -16,7 +16,7 @@ from hydrolib.core.dflowfm.extold.models import (
 )
 from hydrolib.core.dflowfm.inifield import DataFileType, InterpolationMethod
 from hydrolib.tools.extforce_convert.converters import (
-    FACTOR_QUANTITY_BASE,
+    FACTOR_QUANTITIES,
     ConverterFactory,
     SpatialConverter,
 )
@@ -296,9 +296,8 @@ class TestFactorQuantityConversion:
     def test_factor_quantity_in_factor_quantity_base(
         self, factor_quantity: str, expected_base_quantity: str
     ):
-        """All supported factor quantities have an entry in FACTOR_QUANTITY_BASE."""
-        assert factor_quantity in FACTOR_QUANTITY_BASE
-        assert FACTOR_QUANTITY_BASE[factor_quantity] == expected_base_quantity
+        """All supported factor quantities have an entry in FACTOR_QUANTITIES."""
+        assert factor_quantity in FACTOR_QUANTITIES
 
     @pytest.mark.parametrize("factor_quantity, expected_base_quantity", _FACTOR_QUANTITY_CASES)
     def test_polygon_factor_quantity_converts_to_spatial_with_multiply(

--- a/tests/tools/test_converter_spatial.py
+++ b/tests/tools/test_converter_spatial.py
@@ -313,7 +313,7 @@ class TestFactorQuantityConversion:
             filetype=10,
             method=4,
             value=0.8,
-            operand="O",
+            operand=Operand.override,
         )
 
         new_block = SpatialConverter().convert(
@@ -332,7 +332,7 @@ class TestFactorQuantityConversion:
         self, factor_quantity: str, expected_base_quantity: str
     ):
         """The operand is always set to multiply for factor quantities, no matter the original."""
-        for original_operand in ["O", "A", "+", "*", "X", "N"]:
+        for original_operand in list(Operand):
             forcing = ExtOldForcing(
                 quantity=factor_quantity,
                 filename=DiskOnlyFileModel("mask.pol"),

--- a/tests/tools/test_converter_spatial.py
+++ b/tests/tools/test_converter_spatial.py
@@ -16,6 +16,7 @@ from hydrolib.core.dflowfm.extold.models import (
 )
 from hydrolib.core.dflowfm.inifield import DataFileType, InterpolationMethod
 from hydrolib.tools.extforce_convert.converters import (
+    FACTOR_QUANTITY_BASE,
     ConverterFactory,
     SpatialConverter,
 )
@@ -270,6 +271,83 @@ class TestSpatialE2E:
         assert len(structure_model.structure) == 0
         assert len(ext_model.meteo) == 0
 
+
+_FACTOR_QUANTITY_CASES = [
+    pytest.param(
+        "windspeedfactor",
+        "windxy",
+        id="windspeedfactor->windxy",
+    ),
+    pytest.param(
+        "solarradiationfactor",
+        "solarradiation",
+        id="solarradiationfactor->solarradiation",
+    ),
+]
+
+
+class TestFactorQuantityConversion:
+    """
+    Tests that factor quantities (windspeedfactor, solarradiationfactor) are correctly
+    converted to [Spatial] blocks with operand=multiply and the base meteorological quantity.
+    """
+
+    @pytest.mark.parametrize("factor_quantity, expected_base_quantity", _FACTOR_QUANTITY_CASES)
+    def test_factor_quantity_in_factor_quantity_base(
+        self, factor_quantity: str, expected_base_quantity: str
+    ):
+        """All supported factor quantities have an entry in FACTOR_QUANTITY_BASE."""
+        assert factor_quantity in FACTOR_QUANTITY_BASE
+        assert FACTOR_QUANTITY_BASE[factor_quantity] == expected_base_quantity
+
+    @pytest.mark.parametrize("factor_quantity, expected_base_quantity", _FACTOR_QUANTITY_CASES)
+    def test_polygon_factor_quantity_converts_to_spatial_with_multiply(
+        self, factor_quantity: str, expected_base_quantity: str
+    ):
+        """A polygon-based factor quantity converts to a Spatial block with targetMaskFile,
+        dataValue, and operand=multiply, using the base quantity (not the factor quantity name).
+        """
+        forcing = ExtOldForcing(
+            quantity=factor_quantity,
+            filename=DiskOnlyFileModel("mask.pol"),
+            filetype=10,
+            method=4,
+            value=0.8,
+            operand="O",
+        )
+
+        new_block = SpatialConverter().convert(
+            forcing, forcing.filename.filepath)
+
+        assert isinstance(new_block, Spatial)
+        assert new_block.quantity == expected_base_quantity
+        assert new_block.operand == Operand.multiply
+        assert new_block.datavalue == pytest.approx(0.8)
+        assert new_block.targetmaskfile is not None
+        assert new_block.interpolationmethod == InterpolationMethod.constant
+        assert new_block.datafile is None
+
+    @pytest.mark.parametrize("factor_quantity, expected_base_quantity", _FACTOR_QUANTITY_CASES)
+    def test_factor_quantity_operand_is_always_multiply_regardless_of_original(
+        self, factor_quantity: str, expected_base_quantity: str
+    ):
+        """The operand is always set to multiply for factor quantities, no matter the original."""
+        for original_operand in ["O", "A", "+", "*", "X", "N"]:
+            forcing = ExtOldForcing(
+                quantity=factor_quantity,
+                filename=DiskOnlyFileModel("mask.pol"),
+                filetype=10,
+                method=4,
+                value=1.0,
+                operand=original_operand,
+            )
+
+            new_block = SpatialConverter().convert(forcing, forcing.filename.filepath)
+
+            assert new_block.operand == Operand.multiply, (
+                f"Expected multiply for operand={original_operand!r}, "
+                f"got {new_block.operand!r}"
+            )
 
 class TestSpatialExtrapolationConversion:
     """The old external-forcing EXTRAPOLATION_METHOD (0/1) must be carried into the

--- a/tests/tools/test_converter_spatial.py
+++ b/tests/tools/test_converter_spatial.py
@@ -316,7 +316,8 @@ class TestFactorQuantityConversion:
         )
 
         new_block = SpatialConverter().convert(
-            forcing, forcing.filename.filepath)
+            forcing, forcing.filename.filepath
+        )
 
         assert isinstance(new_block, Spatial)
         assert new_block.quantity == expected_base_quantity


### PR DESCRIPTION
# Description
Handle the old extforce quantities `windspeedfactor` and `solarradiationfactor` correctly, mapping them to their new names, as well as using `targetmaskfile` and setting the operand to `multiply`.

- Fixes #1190 

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Added tests covering these 2 quantities

# Checklist:
Prepare items below using:
\[ :x: \] (markdown: `[ :x: ]`) for TODO items
\[ :white_check_mark: \] (markdown: `[ :white_check_mark: ]`) for DONE items
\[ N/A \] for items that are not applicable for this PR.


- [ ] updated version number in setup.py/pyproject.toml/environment.yml.
- [ ] updated the lock file.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
