### PR TITLE
fix forcingfile parsing/serializing for the Boundary class2

### DIFF
--- a/hydrolib/core/dflowfm/ext/models.py
+++ b/hydrolib/core/dflowfm/ext/models.py
@@ -202,7 +202,7 @@ class Boundary(INIBasedModel):
     locationfile: Annotated[
         DiskOnlyFileModel, BeforeValidator(set_default_disk_only_file_model)
     ] = Field(default_factory=lambda: DiskOnlyFileModel(None), alias="locationFile")
-    forcingfile: ForcingModel = Field(alias="forcingFile")
+    forcingfile: ForcingModel | DiskOnlyFileModel = Field(alias="forcingFile")
     bndwidth1d: float | None = Field(None, alias="bndWidth1D")
     bndbldepth: float | None = Field(None, alias="bndBlDepth")
     returntime: float | None = Field(None, alias="returnTime")
@@ -215,8 +215,8 @@ class Boundary(INIBasedModel):
     @classmethod
     def validate_forcingfile(cls, data: Any) -> Any:
         if isinstance(data, (str, Path)):
-            data = ForcingModel(filepath=data)
-        elif not isinstance(data, ForcingModel):
+            data = resolve_file_model(data, ForcingModel)
+        elif not isinstance(data, (ForcingModel, DiskOnlyFileModel)):
             raise TypeError(
                 "Forcing file must be a ForcingModel or a path to a forcing file."
             )
@@ -291,16 +291,19 @@ class Boundary(INIBasedModel):
         """Retrieves the corresponding forcing data for this boundary.
 
         Returns:
-            ForcingBase: The corresponding forcing data, or None when no matching forcing block is found.
+            ForcingBase: The corresponding forcing data, or None when no matching forcing block is
+            found or when the forcing file has not been parsed (e.g. loaded with ``recurse=False``,
+            in which case it is a ``DiskOnlyFileModel`` placeholder).
         """
         result = None
-        for forcing in self.forcingfile.forcing:
-            if self.nodeid == forcing.name and any(
-                quantity.quantity.startswith(self.quantity)
-                for quantity in forcing.quantityunitpair
-            ):
-                result = forcing
-                break
+        if isinstance(self.forcingfile, ForcingModel):
+            for forcing in self.forcingfile.forcing:
+                if self.nodeid == forcing.name and any(
+                    quantity.quantity.startswith(self.quantity)
+                    for quantity in forcing.quantityunitpair
+                ):
+                    result = forcing
+                    break
 
         return result
 

--- a/tests/dflowfm/ext/test_boundary.py
+++ b/tests/dflowfm/ext/test_boundary.py
@@ -346,8 +346,11 @@ class TestBoundaryForcingFileNonRecursiveLoad:
         model.save(filepath=out_path, recurse=True, exclude_unset=True)
 
         saved_text = out_path.read_text(encoding="utf8")
-        assert "forcingFile" in saved_text and "bnd.bc" in saved_text, (
-            f"Saved ext block lost the forcingFile reference:\n{saved_text}"
+        assert "forcingFile" in saved_text, (
+            f"Saved ext block lost the forcingFile keyword:\n{saved_text}"
+        )
+        assert "bnd.bc" in saved_text, (
+            f"Saved ext block lost the .bc reference:\n{saved_text}"
         )
 
         reloaded = ExtModel(filepath=out_path, recurse=False)

--- a/tests/dflowfm/ext/test_boundary.py
+++ b/tests/dflowfm/ext/test_boundary.py
@@ -11,6 +11,7 @@ from hydrolib.core.base.models import DiskOnlyFileModel
 from hydrolib.core.dflowfm import Operand
 from hydrolib.core.dflowfm.bc.models import ForcingModel
 from hydrolib.core.dflowfm.ext.models import Boundary, ExtModel
+from hydrolib.tools.extforce_convert.utils import construct_filemodel_new_or_existing
 
 
 def test_existing_file():
@@ -326,4 +327,72 @@ class TestBoundaryForcingFileNonRecursiveLoad:
         assert bc_path.read_text(encoding="utf8") == original_bc, (
             "The .bc forcing file was rewritten by save(recurse=True); it should have been "
             "left untouched because it was never loaded."
+        )
+
+    def test_save_preserves_forcingfile_reference_after_nonrecursive_load(
+        self, tmp_path: Path
+    ):
+        """Test that saving preserves the ``forcingFile`` reference in the [Boundary] block.
+
+        Test scenario:
+            After a ``recurse=False`` load (where ``forcingFile`` is a ``DiskOnlyFileModel``
+            placeholder), saving must still write ``forcingFile = bnd.bc`` into the ext block,
+            and reloading the saved file must recover the same reference.
+        """
+        ext_path = _write_boundary_ext_tree(tmp_path)
+        out_path = tmp_path / "out.ext"
+
+        model = ExtModel(filepath=ext_path, recurse=False)
+        model.save(filepath=out_path, recurse=True, exclude_unset=True)
+
+        saved_text = out_path.read_text(encoding="utf8")
+        assert "forcingFile" in saved_text and "bnd.bc" in saved_text, (
+            f"Saved ext block lost the forcingFile reference:\n{saved_text}"
+        )
+
+        reloaded = ExtModel(filepath=out_path, recurse=False)
+        assert str(reloaded.boundary[0].forcingfile.filepath) == "bnd.bc", (
+            f"Reloaded forcingFile reference changed: {reloaded.boundary[0].forcingfile.filepath}"
+        )
+
+    def test_forcing_property_returns_none_for_disk_only_placeholder(self, tmp_path: Path):
+        """Test that the ``forcing`` property returns None for an unparsed placeholder.
+
+        Test scenario:
+            When ``forcingfile`` is a ``DiskOnlyFileModel`` (non-recursive load), the
+            ``Boundary.forcing`` property must return ``None`` rather than raise
+            ``AttributeError``.
+        """
+        ext_path = _write_boundary_ext_tree(tmp_path)
+
+        model = ExtModel(filepath=ext_path, recurse=False)
+        boundary = model.boundary[0]
+
+        assert isinstance(boundary.forcingfile, DiskOnlyFileModel), (
+            f"Expected DiskOnlyFileModel, got {type(boundary.forcingfile).__name__}"
+        )
+        assert boundary.forcing is None, (
+            f"Expected forcing property to be None for a placeholder, got {boundary.forcing!r}"
+        )
+
+    def test_converter_load_pattern_does_not_empty_bc(self, tmp_path: Path):
+        """Test the converter's exact load pattern does not empty an existing .bc file.
+
+        Test scenario:
+            Reproduces issue #1143 at the mechanism level: the external-forcings converter
+            loads a pre-existing new-style ext file via
+            ``construct_filemodel_new_or_existing(ExtModel, path, recurse=False)``
+            (``main_converter`` line 128) and later saves with ``recurse=True``. The
+            referenced ``.bc`` file must survive intact.
+        """
+        ext_path = _write_boundary_ext_tree(tmp_path)
+        bc_path = tmp_path / "bnd.bc"
+        original_bc = bc_path.read_text(encoding="utf8")
+
+        model = construct_filemodel_new_or_existing(ExtModel, ext_path, recurse=False)
+        model.save(recurse=True, exclude_unset=True)
+
+        assert bc_path.read_text(encoding="utf8") == original_bc, (
+            "The converter load pattern (recurse=False) followed by save(recurse=True) "
+            "emptied the existing .bc file (issue #1143)."
         )

--- a/tests/dflowfm/ext/test_boundary.py
+++ b/tests/dflowfm/ext/test_boundary.py
@@ -10,7 +10,7 @@ import pytest
 from hydrolib.core.base.models import DiskOnlyFileModel
 from hydrolib.core.dflowfm import Operand
 from hydrolib.core.dflowfm.bc.models import ForcingModel
-from hydrolib.core.dflowfm.ext.models import Boundary
+from hydrolib.core.dflowfm.ext.models import Boundary, ExtModel
 
 
 def test_existing_file():
@@ -223,3 +223,107 @@ class TestBoundaryLegacyOperandConversion:
 
         created_boundary = Boundary(**dict_values)
         assert created_boundary.operand == expected_operand
+
+
+_BC_CONTENT = (
+    "[Forcing]\n"
+    "name              = L1_0001\n"
+    "function          = timeseries\n"
+    "timeInterpolation = linear\n"
+    "quantity          = time\n"
+    "unit              = minutes since 2015-01-01 00:00:00\n"
+    "quantity          = waterlevelbnd\n"
+    "unit              = m\n"
+    "0.0   0.01\n"
+    "120.0 0.01\n"
+)
+
+_EXT_CONTENT = (
+    "[Boundary]\n"
+    "quantity     = waterlevelbnd\n"
+    "locationFile = bnd.pli\n"
+    "forcingFile  = bnd.bc\n"
+)
+
+
+def _write_boundary_ext_tree(directory: Path) -> Path:
+    """Write a new-style ext file referencing a real .bc forcing file.
+
+    Args:
+        directory: Directory in which to create ``new.ext``, ``bnd.bc`` and ``bnd.pli``.
+
+    Returns:
+        Path: The path to the written ``new.ext`` file.
+    """
+    (directory / "bnd.bc").write_text(_BC_CONTENT, encoding="utf8")
+    (directory / "bnd.pli").write_text("bnd\n2 2\n0 0\n0 1\n", encoding="utf8")
+    ext_path = directory / "new.ext"
+    ext_path.write_text(_EXT_CONTENT, encoding="utf8")
+    return ext_path
+
+
+class TestBoundaryForcingFileNonRecursiveLoad:
+    """Regression tests for the ``recurse=False`` load / ``recurse=True`` save round-trip.
+
+    When an ``ExtModel`` is loaded non-recursively (as the external-forcings converter
+    does), the ``.bc`` forcing file referenced by a ``[Boundary]`` block must not be
+    parsed into an (empty) ``ForcingModel``. It must instead be held as a
+    ``DiskOnlyFileModel`` placeholder, so that a subsequent ``save(recurse=True)`` leaves
+    the real ``.bc`` file untouched instead of overwriting it with empty content.
+    """
+
+    def test_forcingfile_is_disk_only_when_loaded_non_recursively(self, tmp_path: Path):
+        """Test that a non-recursive load keeps the forcing file as a DiskOnlyFileModel.
+
+        Test scenario:
+            Loading an ext file with ``recurse=False`` must resolve ``forcingFile`` to a
+            ``DiskOnlyFileModel`` (the on-disk-but-not-parsed placeholder), NOT an empty
+            ``ForcingModel``.
+        """
+        ext_path = _write_boundary_ext_tree(tmp_path)
+
+        model = ExtModel(filepath=ext_path, recurse=False)
+
+        forcingfile = model.boundary[0].forcingfile
+        assert isinstance(forcingfile, DiskOnlyFileModel), (
+            f"Expected DiskOnlyFileModel under recurse=False, got {type(forcingfile).__name__}"
+        )
+
+    def test_forcingfile_is_forcingmodel_when_loaded_recursively(self, tmp_path: Path):
+        """Test that a recursive load parses the forcing file into a ForcingModel.
+
+        Test scenario:
+            Loading the same ext file with ``recurse=True`` fully parses ``forcingFile``
+            into a ``ForcingModel`` carrying the forcing blocks.
+        """
+        ext_path = _write_boundary_ext_tree(tmp_path)
+
+        model = ExtModel(filepath=ext_path, recurse=True)
+
+        forcingfile = model.boundary[0].forcingfile
+        assert isinstance(forcingfile, ForcingModel), (
+            f"Expected ForcingModel under recurse=True, got {type(forcingfile).__name__}"
+        )
+        assert len(forcingfile.forcing) == 1, (
+            f"Expected 1 forcing block parsed, got {len(forcingfile.forcing)}"
+        )
+
+    def test_save_recurse_does_not_empty_unloaded_bc_file(self, tmp_path: Path):
+        """Test that saving recursively does not clobber a non-recursively loaded .bc file.
+
+        Test scenario:
+            Load the ext file with ``recurse=False`` (leaving ``.bc`` unparsed), then
+            ``save(recurse=True)``. The referenced ``bnd.bc`` must retain its original
+            content rather than being overwritten with an empty forcing file.
+        """
+        ext_path = _write_boundary_ext_tree(tmp_path)
+        bc_path = tmp_path / "bnd.bc"
+        original_bc = bc_path.read_text(encoding="utf8")
+
+        model = ExtModel(filepath=ext_path, recurse=False)
+        model.save(recurse=True, exclude_unset=True)
+
+        assert bc_path.read_text(encoding="utf8") == original_bc, (
+            "The .bc forcing file was rewritten by save(recurse=True); it should have been "
+            "left untouched because it was never loaded."
+        )


### PR DESCRIPTION
# Description

- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context.
- List any dependencies that are required for this change.


# Issues 
- Fixes #1143 
## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Please describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:
Prepare items below using:
\[ :x: \] (markdown: `[ :x: ]`) for TODO items
\[ :white_check_mark: \] (markdown: `[ :white_check_mark: ]`) for DONE items
\[ N/A \] for items that are not applicable for this PR.


- [ ] updated version number in setup.py/pyproject.toml/environment.yml.
- [ ] updated the lock file.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
