### PR TITLE
fix: missing header from new ext file

### DIFF
--- a/hydrolib/core/dflowfm/ext/models.py
+++ b/hydrolib/core/dflowfm/ext/models.py
@@ -1043,7 +1043,7 @@ class ExtGeneral(INIGeneral):
     """The external forcing file's `[General]` section with file meta-data."""
 
     _header: Literal["General"] = "General"
-    fileversion: str = Field("2.01", alias="fileVersion")
+    fileversion: str = Field("3.00", alias="fileVersion")
     filetype: Literal["extForce"] = Field("extForce", alias="fileType")
 
 

--- a/hydrolib/tools/extforce_convert/main_converter.py
+++ b/hydrolib/tools/extforce_convert/main_converter.py
@@ -1,4 +1,4 @@
-"""Converter for old external forcing files to the new format."""
+﻿"""Converter for old external forcing files to the new format."""
 
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ from hydrolib.core.base.file_manager import PathOrStr
 from hydrolib.core.base.utils import PathStyle
 from hydrolib.core.dflowfm.ext.models import (
     Boundary,
+    ExtGeneral,
     ExtModel,
     Lateral,
     Meteo,
@@ -21,7 +22,11 @@ from hydrolib.core.dflowfm.ext.models import (
 )
 from hydrolib.core.dflowfm.extold.models import ExtOldModel
 from hydrolib.core.dflowfm.mba.models import MassBalanceArea, MassBalanceAreaModel
-from hydrolib.core.dflowfm.structure.models import Structure, StructureModel
+from hydrolib.core.dflowfm.structure.models import (
+    Structure,
+    StructureGeneral,
+    StructureModel,
+)
 from hydrolib.tools.extforce_convert.converters import (
     BoundaryConditionConverter,
     ConverterFactory,
@@ -444,6 +449,13 @@ class ExternalForcingConverter:
         if self.ext_model.n_forcing_blocks:
             if backup and self.ext_model.filepath.exists():
                 backup_file(self.ext_model.filepath)
+
+            # explicitly set the [General] block to ensure its always written to the new external forcing file.
+            # without it, the ext file will be saved without it as the exclude_unset=True
+            self.ext_model.general = ExtGeneral(
+                fileVersion=self.ext_model.general.fileversion,
+                fileType=self.ext_model.general.filetype,
+            )
             self.ext_model.save(
                 recurse=recursive, exclude_unset=True, path_style=self.path_style
             )
@@ -455,6 +467,13 @@ class ExternalForcingConverter:
     def _save_structure_model(self, backup: bool, recursive: bool):
         if backup and self.structure_model.filepath.exists():
             backup_file(self.structure_model.filepath)
+
+        # explicitly set the [General] block to ensure its always written to the new structure file.
+        # without it, the structure file will be saved without it as the exclude_unset=True
+        self.structure_model.general = StructureGeneral(
+            fileVersion=self.structure_model.general.fileversion,
+            fileType=self.structure_model.general.filetype,
+        )
         self.structure_model.save(
             recurse=recursive, exclude_unset=True, path_style=self.path_style
         )

--- a/tests/dflowfm/ext/test_ext.py
+++ b/tests/dflowfm/ext/test_ext.py
@@ -449,7 +449,7 @@ class TestMeteoWireFormatRoundTrip:
 
     MINIMAL_INI = (
         "[General]\n"
-        "fileVersion = 2.01\n"
+        "fileVersion = 3.00\n"
         "fileType    = extForce\n"
         "\n"
         "[Meteo]\n"

--- a/tests/dflowfm/ext/test_spatial.py
+++ b/tests/dflowfm/ext/test_spatial.py
@@ -36,7 +36,7 @@ def _write_ext(directory: Path, spatial_body: str) -> Path:
     """Write a minimal new-format `.ext` with a single `[Spatial]` block and return its path."""
     content = (
         "[General]\n"
-        "fileVersion = 2.01\n"
+        "fileVersion = 3.00\n"
         "fileType    = extForce\n"
         "\n"
         "[Spatial]\n"

--- a/tests/tools/test_main_converter.py
+++ b/tests/tools/test_main_converter.py
@@ -9,6 +9,7 @@ import pytest
 from hydrolib.core.base.utils import FilePathStyleConverter, PathStyle
 from hydrolib.core.dflowfm.ext.models import (
     Boundary,
+    ExtGeneral,
     ExtModel,
     Lateral,
     Meteo,
@@ -108,6 +109,32 @@ class TestExtOldToNewFromMDU:
         mdu_text = mdu_filename.read_text()
         assert "ExtForceFileNew" in mdu_text
         assert new_ext_name in mdu_text
+
+    def test_saved_ext_file_has_general_header(
+        self, monkeypatch, tmp_path: Path, input_files_dir: Path
+    ):
+        """Regression: the saved new .ext file must carry its [General] header.
+
+        The [General] block (fileVersion/fileType) identifies the file to the
+        kernel. It is a model default (unset), so saving the ext model with
+        exclude_unset=True used to drop it, producing a file with no header.
+        """
+        monkeypatch.setattr(main_converter, "_verbose", True, raising=False)
+        src = input_files_dir / "e02/f006_external_forcing/c011_extrapolate_slr"
+        model_dir = tmp_path / src.name
+        shutil.copytree(src, model_dir)
+        mdu_filename = model_dir / "slrextrapol.mdu"
+
+        converter = ExternalForcingConverter.from_mdu(mdu_filename)
+        ext_model, _ = converter.update()
+        assert ext_model.n_forcing_blocks == 1
+
+        converter.save()
+
+        text = ext_model.filepath.read_text()
+        assert "[General]" in text, f"Missing [General] block in:\n{text[:200]}"
+        assert "fileVersion" in text, f"Missing fileVersion in:\n{text[:200]}"
+        assert "fileType" in text, f"Missing fileType in:\n{text[:200]}"
 
     def test_recursive(self, capsys, monkeypatch, input_files_dir: Path):
         monkeypatch.setattr(main_converter, "_verbose", True, raising=False)
@@ -327,6 +354,7 @@ class TestExternalFocingConverter:
         ):
             converter = ExternalForcingConverter(mock_ext_old_model)
         converter._ext_model = MagicMock(spec=ExtModel)
+        converter._ext_model.general = ExtGeneral()
         converter._ext_model.meteo = [MagicMock(spec=Meteo)]
         converter._ext_model.spatial = [MagicMock(spec=Spatial)]
         converter._ext_model.sourcesink = [MagicMock(spec=SourceSink)]
@@ -476,6 +504,51 @@ class TestExternalFocingConverter:
         converter.structure_model.structure = []
         converter._update_mdu_file()
         mock_mdu_parser.update_structure_file.assert_not_called()
+
+    def test_saved_structure_file_has_general_header(self, tmp_path: Path):
+        """Regression: the saved structure file must carry its [General] header.
+
+        Like the new .ext file, the structure model's [General] block
+        (fileVersion/fileType) is a model default (unset) and was dropped by
+        exclude_unset, producing a structure file with no header.
+        """
+        mock_ext_old_model = MagicMock(spec=ExtOldModel)
+        mock_ext_old_model.filepath = Path("tests/data/input/mock_file.ext")
+        with (
+            patch(
+                "hydrolib.tools.extforce_convert.main_converter."
+                "ExternalForcingConverter._read_old_file",
+                return_value=mock_ext_old_model,
+            ),
+            patch(
+                "hydrolib.tools.extforce_convert.utils."
+                "ConverterData.check_unsupported_quantities",
+                return_value=None,
+            ),
+        ):
+            converter = ExternalForcingConverter(mock_ext_old_model)
+
+        converter.structure_model.filepath = tmp_path / "new-structure.ini"
+        converter.structure_model.structure = [
+            Weir(
+                id="weir_id",
+                name="W001",
+                branchid="branch",
+                chainage=3.0,
+                allowedflowdir=FlowDirection.positive,
+                crestlevel=10.5,
+                crestwidth=None,
+                usevelocityheight=False,
+                _header="Structure",
+            )
+        ]
+
+        converter._save_structure_model(backup=False, recursive=True)
+
+        text = converter.structure_model.filepath.read_text()
+        assert "[General]" in text, f"Missing [General] block in:\n{text[:200]}"
+        assert "fileVersion" in text, f"Missing fileVersion in:\n{text[:200]}"
+        assert "fileType" in text, f"Missing fileType in:\n{text[:200]}"
 
     @pytest.fixture
     def setup_absolute_path_files(self, request, tmp_path: Path) -> dict:


### PR DESCRIPTION
# Description

The external forcing converter wrote the new-style `.ext` file (and the generated structure file) without
their `[General]` block, so the `fileVersion`/`fileType` metadata that identifies the file to the D-Flow FM
kernel was missing.

Root cause: `general` is a defaulted, never-set field on `ExtModel`/`StructureModel`, and the converter
saves these models with `exclude_unset=True` (to keep the forcing/structure blocks lean). `exclude_unset`
recurses into the unset `[General]` block and drops it.

Fix: in `ExternalForcingConverter`, explicitly re-set the `[General]` block (with its current
`fileVersion`/`fileType` values) before saving the ext and structure models, so the header is always
written while the blocks stay lean. This mirrors how the mass balance area file already forces its
`[General]` block via `_save_mba_model`.

# Issues
- Fixes #1199

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Two regression tests were added in `tests/tools/test_main_converter.py`:

- `test_saved_ext_file_has_general_header` — converts the `slrextrapol` model, saves, and asserts the new
  `.ext` file contains `[General]`, `fileVersion`, and `fileType`.
- `test_saved_structure_file_has_general_header` — saves a structure model with one `Weir` and asserts the
  structure file contains the same header.

Both fail without the fix and pass with it. The full `tests/tools` suite passes locally (530 passed).

# Checklist:
Prepare items below using:
\[ :x: \] (markdown: `[ :x: ]`) for TODO items
\[ :white_check_mark: \] (markdown: `[ :white_check_mark: ]`) for DONE items
\[ N/A \] for items that are not applicable for this PR.


- [ N/A ] updated version number in setup.py/pyproject.toml/environment.yml.
- [ N/A ] updated the lock file.
- [ N/A ] added changes to History.rst.
- [ N/A ] updated the latest version in README file.
- [ :white_check_mark: ] I have added tests that prove my fix is effective or that my feature works.
- [ :white_check_mark: ] New and existing unit tests pass locally with my changes.
- [ N/A ] documentation are updated.
